### PR TITLE
Add missing capture in reverse_inplace lambda

### DIFF
--- a/include/parlay/primitives.h
+++ b/include/parlay/primitives.h
@@ -614,7 +614,7 @@ auto reverse(const R& r) {
 template <PARLAY_RANGE_TYPE R>
 auto reverse_inplace(R&& r) {
   auto n = parlay::size(r);
-  parallel_for(0, n/2, [it = std::begin(r)] (size_t i) {
+  parallel_for(0, n/2, [n, it = std::begin(r)] (size_t i) {
     std::swap(it[i], it[n - i - 1]);
   });
 }


### PR DESCRIPTION
This fixes the following compile error:

```cpp
In file included from ../test/test_random.cpp:3:
../include/parlay/primitives.h: In lambda function:
../include/parlay/primitives.h:618:25: error: ‘n’ is not captured
  618 |     std::swap(it[i], it[n - i - 1]);
      |                         ^
```