### PR TITLE
Bug Fix: minmaxm() constructor

### DIFF
--- a/include/parlay/monoid.h
+++ b/include/parlay/monoid.h
@@ -114,7 +114,7 @@ struct xorm {
 template <class TT>
 struct minmaxm {
   using T = std::pair<TT, TT>;
-  minmaxm() : identity(T(highest<T>(), lowest<T>())) {}
+  minmaxm() : identity(T(highest<TT>(), lowest<TT>())) {}
   T identity;
   static T f(T a, T b) {
     return T((std::min)(a.first, b.first), (std::max)(a.second, b.second));


### PR DESCRIPTION
The constructor creates a pair of the highest and lowest values of type `T`, but it should be `TT`.