### PR TITLE
block_allocator: Fix segfault on small block sizes

### DIFF
--- a/include/parlay/internal/block_allocator.h
+++ b/include/parlay/internal/block_allocator.h
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <cmath>
 
+#include <algorithm>
 #include <atomic>
 #include <optional>
 
@@ -124,6 +125,10 @@ public:
 		  size_t reserved_blocks = 0, 
 		  size_t list_length_ = 0, 
 		  size_t max_blocks_ = 0) : thread_count(num_workers()) {
+    // Each block needs to be at least large enough to hold the struct
+    // representing a free block.
+    block_size = std::max(block_size, sizeof(block));
+
     blocks_allocated.store(0);
     block_size_ = block_size;
     if (list_length_ == 0)

--- a/include/parlay/internal/block_allocator.h
+++ b/include/parlay/internal/block_allocator.h
@@ -127,7 +127,7 @@ public:
 		  size_t max_blocks_ = 0) : thread_count(num_workers()) {
     // Each block needs to be at least large enough to hold the struct
     // representing a free block.
-    block_size = std::max(block_size, sizeof(block));
+    block_size = std::max<size_t>(block_size, sizeof(block));
 
     blocks_allocated.store(0);
     block_size_ = block_size;

--- a/test/test_allocator.cpp
+++ b/test/test_allocator.cpp
@@ -40,6 +40,17 @@ TEST(TestAllocator, TestTypeAllocator) {
   vector_allocator::free(mem);
 }
 
+// Checks that type_allocator allocates small blocks successfully.
+TEST(TestAllocator, TestTypeAllocatorForSmallSizes) {
+  using char_allocator = parlay::type_allocator<char>;
+  char* a = char_allocator::alloc();
+  *a = 'A';
+  char* b = char_allocator::alloc();
+  *b = 'B';
+  char_allocator::free(a);
+  char_allocator::free(b);
+}
+
 struct alignas(256) StrangeAlignedStruct {
   int x;
 };


### PR DESCRIPTION
## Changes

Bug: `block_allocator` will break if used with a block size below `sizeof(block_allocator::block)` (`== 8` on 64-bit machines). For instance, in `initialize_list()`, assigning to `p->next` will overwrite the contents of the block preceding `p`.

Fix: Patch `block_allocator` to have block sizes `>= sizeof(block_allocator::block)`.

Admittedly, allocating such small objects is of usually of dubious value, but it's useful for, say, allocating values in a templated class where the type of the value is arbitrary (and potentially small) due to being templated.

## Testing

Added a test in `test_allocator.cpp`. On `master`, the test segfaults on the line `char* b = char_allocator::alloc();`, whereas the test succeeds on this PR branch.