### PR TITLE
integer_sort: Make get_counts() not crash on empty inputs

### DIFF
--- a/include/parlay/internal/integer_sort.h
+++ b/include/parlay/internal/integer_sort.h
@@ -355,6 +355,9 @@ auto integer_sort(slice<Iterator, Iterator> In,
 // The last element contains the size of the input.
 template <typename Tint = size_t, typename Iterator, typename Get_Key>
 sequence<Tint> get_counts(slice<Iterator, Iterator> In, Get_Key const &g, size_t num_buckets) {
+  if (In.size() == 0) {
+    return {};
+  }
   size_t n = In.size();
   sequence<Tint> starts(num_buckets, (Tint)0);
   sequence<Tint> ends(num_buckets, (Tint)0);
@@ -371,6 +374,10 @@ sequence<Tint> get_counts(slice<Iterator, Iterator> In, Get_Key const &g, size_t
 
 template <typename Tint = size_t, typename Iterator, typename Get_Key>
 auto integer_sort_with_counts(slice<Iterator, Iterator> In, Get_Key const &g, size_t num_buckets) {
+  using T = typename slice<Iterator, Iterator>::value_type;
+  if (In.size() == 0) {
+    return std::make_pair(parlay::sequence<T>{}, parlay::sequence<Tint>{});
+  }
   assert(num_buckets > 0);
   size_t bits = log2_up(num_buckets);
   auto R = integer_sort(In, g, bits);

--- a/include/parlay/internal/integer_sort.h
+++ b/include/parlay/internal/integer_sort.h
@@ -355,10 +355,10 @@ auto integer_sort(slice<Iterator, Iterator> In,
 // The last element contains the size of the input.
 template <typename Tint = size_t, typename Iterator, typename Get_Key>
 sequence<Tint> get_counts(slice<Iterator, Iterator> In, Get_Key const &g, size_t num_buckets) {
-  if (In.size() == 0) {
+  size_t n = In.size();
+  if (n == 0) {
     return {};
   }
-  size_t n = In.size();
   sequence<Tint> starts(num_buckets, (Tint)0);
   sequence<Tint> ends(num_buckets, (Tint)0);
   parallel_for(0, n - 1, [&](size_t i) {

--- a/test/test_integer_sort.cpp
+++ b/test/test_integer_sort.cpp
@@ -15,6 +15,16 @@ namespace parlay {
   struct is_trivially_relocatable<std::unique_ptr<T>> : public std::true_type { };
 }
 
+TEST(TestIntegerSort, TestIntegerSortEmptyInput) {
+  auto s = parlay::sequence<int>(0);
+  const auto [sorted, counts] = parlay::internal::integer_sort_with_counts(
+    make_slice(s),
+    [](const int x) { return x; },
+    1);
+  EXPECT_EQ(sorted.size(), 0);
+  EXPECT_EQ(counts.size(), 0);
+}
+
 TEST(TestIntegerSort, TestIntegerSortInplaceUniquePtr) {
   auto s = parlay::tabulate(100000, [](long long int i) {
     return std::make_unique<long long int>((50021 * i + 61) % (1 << 20));


### PR DESCRIPTION
Issues:
- `parlay::internal::get_counts` crashes on empty input slices
- `parlay::internal::integer_sort_with_counts` also crashes due to using `get_counts`, and also it asserts that `num_buckets > 0` even though `num_buckets == 0` is valid if the input slice is empty

This PR fixes the issues by adding a check in front of both functions.