### PR TITLE
Fix quadratic-time behavior with parlay::internal::quicksort

### DIFF
--- a/include/parlay/internal/quicksort.h
+++ b/include/parlay/internal/quicksort.h
@@ -70,14 +70,14 @@ void insertion_sort(Iterator A, size_t n, const BinPred& f) {
   }
 }
 
-// sorts 5 elements taken at even stride and puts them at the front
+// Sorts 5 sampled elements and puts them at the front.
 template <class Iterator, class BinPred>
 void sort5(Iterator A, size_t n, const BinPred& f) {
   size_t size = 5;
-  size_t m = n / (size + 1);
-  for (size_t l = 0; l < size; l++) {
-    using std::swap;
-    swap(A[l], A[m * (l + 1)]);
+  for (size_t i = 0; i < size; ++i) {
+    size_t j = i + parlay::hash64(i) % (n - i);
+    using std::swap;  // enable ADL.
+    swap(A[i], A[j]);
   }
   insertion_sort(A, size, f);
 }


### PR DESCRIPTION
The issue is due to quadratic-time behavior in the parlay::internal::quicksort algorithm, which we observed when using parlay::sort_inplace. This algorithm is used to process a bucket in sample_sort when using a non-stable sort.

The bad example to trigger this behavior is the case when a single bucket in the sample_sort consists of two distinct elements. In this case, the five pivots that get selected can contain 2 occurrences of one element, and 3 occurrences of the other. The dual pivots that we pick are then the two distinct elements. When we recurse, the entire input falls into the middle bucket, and so we only decrease the input by 1 element for the middle bucket (since we get rid of the second pivot). The issue is caused due to the pivot selection strategy of selecting the [1/6, 2/6, 3/6, 4/6, 5/6]-th percentile elements, which, if it gets unlucky will always end up picking two occurrences of one element, and three occurrences of the other. Importantly, this behavior carries over to the recursive call since split3 doesn't shuffle the data within each bucket. I tried using the [10, 30, 50, 70, 90]-th percentile elements as the split points to see if there is some brittleness due to the particular split points used previously, but also observed the same behavior.

A simple fix for this is to use a few iterations of Knuth shuffle (the same idea used to generate the pivots in sample_sort) when computing the dual pivots in split_5. Making this change fixed the issue described above. I also observed essentially the same performance in the sample_sort code on uniform_random instances which is probably because we switch to a different algorithm for small enough (n < 256) inputs, so the overhead of hashing doesn't affect the leaves of the call tree.

Note that this issue is only triggered when we sort elements > 8 bytes, since for elements <= 8 bytes, the seq_sort_inplace code called by sample_sort just calls bucket_sort.