### PR TITLE
Fix sequence alignment and sequence insert overload when taking a non-const reference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # -------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 3.14)
-project(PARLAY VERSION 2.0.0
+project(PARLAY VERSION 2.0.1
         DESCRIPTION "A collection of parallel algorithms and other support for parallelism in C++"
         LANGUAGES CXX)
 

--- a/include/parlay/internal/sequence_base.h
+++ b/include/parlay/internal/sequence_base.h
@@ -38,7 +38,7 @@ namespace sequence_internal {
 //  Allocator = An allocator for elements of type T
 //  EnableSSO = True to enable small-size optimization
 template<typename T, typename Allocator, bool EnableSSO>
-struct sequence_base {
+struct alignas(uint64_t) sequence_base {
 
   // Only use SSO for trivial types
   constexpr static bool use_sso = EnableSSO && std::is_trivial<T>::value;

--- a/include/parlay/sequence.h
+++ b/include/parlay/sequence.h
@@ -292,8 +292,11 @@ class sequence : protected sequence_internal::sequence_base<T, Allocator, Enable
     return insert_dispatch(p, i, j, std::is_integral<Iterator_>());
   }
 
-  template<typename R>
-  iterator insert(iterator p, R&& r) {
+  template<typename Range,
+    std::enable_if_t<!std::is_same_v<std::decay_t<Range>, value_type> &&
+                      is_input_range_v<Range> &&
+                      std::is_constructible_v<value_type, range_reference_type_t<Range>>, int> = 0>
+  iterator insert(iterator p, Range&& r) {
     return insert(p, std::begin(r), std::end(r));
   }
 

--- a/test/test_sequence.cpp
+++ b/test/test_sequence.cpp
@@ -24,6 +24,8 @@ static_assert(sizeof(parlay::sequence<int>) <= 16);
 static_assert(sizeof(parlay::short_sequence<int>) <= 16);
 #endif
 
+static_assert(alignof(parlay::sequence<int>) >= 8);
+
 
 TEST(TestSequence, TestDefaultConstruct) {
   auto s = parlay::sequence<int>();
@@ -416,6 +418,15 @@ TEST(TestSequence, TestInsert) {
   auto s2 = parlay::sequence<int>{1,2,3,4,5};
   ASSERT_FALSE(s.empty());
   s.insert(s.begin() + 2, 3);
+  ASSERT_EQ(s, s2);
+}
+
+TEST(TestSequence, TestInsertRef) {
+  auto s = parlay::sequence<int>{1,2,4,5};
+  auto s2 = parlay::sequence<int>{1,2,3,4,5};
+  ASSERT_FALSE(s.empty());
+  int x = 3;
+  s.insert(s.begin() + 2, x);
   ASSERT_EQ(s, s2);
 }
 


### PR DESCRIPTION
Sequences were not always 8 byte aligned, and the insert overload that should only accept a range was being preferred when give a `value_type&` parameter, leading to a compile error.