### PR TITLE
Make block allocator conservative again 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # -------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 3.14)
-project(PARLAY VERSION 2.1.0
+project(PARLAY VERSION 2.1.1
         DESCRIPTION "A collection of parallel algorithms and other support for parallelism in C++"
         LANGUAGES CXX)
 

--- a/include/parlay/internal/block_allocator.h
+++ b/include/parlay/internal/block_allocator.h
@@ -85,7 +85,7 @@ struct block_allocator {
   auto initialize_list(std::byte* buffer) const -> block* {
     parallel_for (0, list_length - 1, [&] (size_t i) {
       new (buffer + i * block_size) block{get_block(buffer, i+1)};
-    });
+    }, 0, true);
     new (buffer + (list_length - 1) * block_size) block{nullptr};
     return get_block(buffer, 0);
   }


### PR DESCRIPTION
in case of user code that allocates while holding a lock