### PR TITLE
Fix compilation of TBB scheduler plugin

### DIFF
--- a/include/parlay/internal/scheduler_plugins/tbb.h
+++ b/include/parlay/internal/scheduler_plugins/tbb.h
@@ -13,7 +13,7 @@ namespace parlay {
 // IWYU pragma: private, include "../../parallel.h"
 
 inline size_t num_workers() { return tbb::this_task_arena::max_concurrency(); }
-inline size_t worker_id() { return tbb::task_arena::current_thread_index(); }
+inline size_t worker_id() { return tbb::this_task_arena::current_thread_index(); }
 
 template <class F>
 inline void parallel_for(size_t start, size_t end, F f, long granularity, bool) {


### PR DESCRIPTION
The TBB scheduler plugin fails to compile. This fixes it.