### PR TITLE
Fix suffix array bug

### DIFF
--- a/examples/suffix_array.h
+++ b/examples/suffix_array.h
@@ -83,7 +83,7 @@ auto suffix_array(const char_range& S) {
       index l = segment.end - segment.start;
       auto p = parlay::tabulate(l, [&] (long i) {
         index k = sorted[s + i];
-        return std::pair{(k + offset >= n) ? 0 : ranks[k + offset], k};}, granularity);
+        return std::pair{(k + offset >= n) ? 0 : ranks[k + offset] + 1, k};}, granularity);
       parlay::sort_inplace(p);
       parlay::sequence<bool> flags(l);
       parlay::parallel_for(0, l, [&] (long i) {


### PR DESCRIPTION
For string `abababababababababab` (ten `ab`), the code fails to compare `s[6]` and `s[8]`, because it compares `ranks[18]` (which is 0) and `ranks[20]` (which is also 0 because the index >= 20).