### PR TITLE
Fix overrun/underrun in parlay::sort

### DIFF
--- a/include/parlay/internal/quicksort.h
+++ b/include/parlay/internal/quicksort.h
@@ -110,8 +110,8 @@ std::tuple<Iterator, Iterator, bool> split3(Iterator A, size_t n, const BinPred&
   // set up initial invariants
   auto L = A + 2;
   auto R = A + n - 1;
-  while (f(*L, p1)) L++;
-  while (f(p2, *R)) R--;
+  while (L < A + n - 1 && f(*L, p1)) L++;
+  while (R >= A + 2 && f(p2, *R)) R--;
   auto M = L;
   
   // invariants:


### PR DESCRIPTION
See https://github.com/cmuparlay/parlaylib/issues/35#issue-1551955357

The issue happens in the below loops: 
```
auto L = A + 2;
auto R = A + n - 1;
while (f(*L, p1)) L++;
while (f(p2, *R)) R--;
```
To my understanding, `f` is the comparison function used for sorting, while `p1=A[0]` and `p2=A[1]` are the pivots. The two loops may overrun the buffer if all elements are less than pivot `p1`, and underrun the buffer when all elements are greater than pivot `p2`. There's also the possibility that loops don't terminate, depending on what is stored in contiguous memory.

Proposed change:
```
auto L = A + 2;
auto R = A + n - 1;
while (L < A + n - 1 && f(*L, p1)) L++;
while (R >= A + 2 && f(p2, *R)) R--;
```

I'm not sure whether this change preserves the correctness of the algorithm, but it does avoid the crash. Could someone take a look? Thank you!