### PR TITLE
Update CI for Ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,7 +274,7 @@ jobs:
           ctest -C Debug --no-tests=error --output-on-failure
 
   opencilk:
-    name: ubuntu-22.04 Open Cilk 2.0.0 (Clang 14) (Debug)
+    name: ubuntu-22.04 Open Cilk 2.0.0 (Clang 15) (Debug)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-22.04
     steps:
@@ -283,20 +283,19 @@ jobs:
       - name: Install OpenCilk
         shell: bash
         run: |
-          sudo apt-get -qq install gcc g++
-          git clone https://github.com/OpenCilk/cilkrts.git
-          mkdir cilkrts/build && pushd cilkrts/build
-          cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=/usr/local/ ..
-          make && sudo make install
-          popd
           wget --quiet https://github.com/OpenCilk/opencilk-project/releases/download/opencilk%2Fv2.0/OpenCilk-2.0.0-x86_64-Linux-Ubuntu-22.04.tar.gz
           tar -xf OpenCilk-2.0.0-x86_64-Linux-Ubuntu-22.04.tar.gz
+          git clone https://github.com/OpenCilk/cilkrts.git
+          mkdir cilkrts/build && pushd cilkrts/build
+          cmake -DCMAKE_C_COMPILER=$PWD/../../OpenCilk-2.0.0-x86_64-Linux-Ubuntu-22.04/bin/clang -DCMAKE_CXX_COMPILER=$PWD/../../OpenCilk-2.0.0-x86_64-Linux-Ubuntu-22.04/bin/clang++ -DCMAKE_INSTALL_PREFIX=/usr/local/ ..
+          make && sudo make install
+          popd
 
       - name: Configure
         shell: bash
         run: |
           mkdir build && cd build
-          cmake -DCMAKE_C_COMPILER=$PWD/../OpenCilk-2.0.0-x86_64-Linux-Ubuntu-20.04/bin/clang -DCMAKE_CXX_COMPILER=$PWD/../OpenCilk-2.0.0-x86_64-Linux-Ubuntu-20.04/bin/clang++ -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DPARLAY_NO_TEST_SCHEDULER=True -DCMAKE_CXX_FLAGS="-fopencilk -DPARLAY_OPENCILK" -DCMAKE_EXE_LINKER_FLAGS="-fopencilk -ldl" -DPARLAY_BENCHMARK=On -DPARLAY_EXAMPLES=On ..
+          cmake -DCMAKE_C_COMPILER=$PWD/../OpenCilk-2.0.0-x86_64-Linux-Ubuntu-22.04/bin/clang -DCMAKE_CXX_COMPILER=$PWD/../OpenCilk-2.0.0-x86_64-Linux-Ubuntu-22.04/bin/clang++ -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DPARLAY_NO_TEST_SCHEDULER=True -DCMAKE_CXX_FLAGS="-fopencilk -DPARLAY_OPENCILK" -DCMAKE_EXE_LINKER_FLAGS="-fopencilk -ldl" -DPARLAY_BENCHMARK=On -DPARLAY_EXAMPLES=On ..
 
       - name: Build
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -469,7 +469,7 @@ jobs:
         shell: bash
         run: |
           mkdir build && cd build
-          CC=clang-15 CXX=clang++-15 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DBUILD_ASAN_TESTS=On -DBUILD_ONLY_SANITIZED=True -DUSE_LIBCXX=True ..
+          CC=clang-15 CXX=clang++-15 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DBUILD_ASAN_TESTS=On -DBUILD_ONLY_SANITIZED=True ..
 
       - name: Build
         shell: bash
@@ -501,7 +501,7 @@ jobs:
         shell: bash
         run: |
           mkdir build && cd build
-          CC=clang-15 CXX=clang++-15 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DBUILD_UBSAN_TESTS=On -DBUILD_ONLY_SANITIZED=True -DUSE_LIBCXX=True ..
+          CC=clang-15 CXX=clang++-15 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DBUILD_UBSAN_TESTS=On -DBUILD_ONLY_SANITIZED=True ..
 
       - name: Build
         shell: bash
@@ -526,13 +526,13 @@ jobs:
       - name: Install LCov
         shell: bash
         run: |
-          sudo apt-get -qq install gcc-12 g++-12 lcov
+          sudo apt-get -qq install gcc g++ lcov
 
       - name: Configure
         shell: bash
         run: |
           mkdir build && cd build
-          CC=gcc-12 CXX=g++-12 cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG=" --coverage " -DPARLAY_TEST=On ..
+          CC=gcc CXX=g++ cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG=" --coverage " -DPARLAY_TEST=On ..
 
       - name: Build
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           elif [[ "${{ matrix.config.os }}" == "ubuntu-22.04" ]]; then
             sudo add-apt-repository ppa:ubuntu-toolchain-r/test
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-            sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-jammy-15 main"
+            sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
           fi
 
       - name: Install Compiler
@@ -140,7 +140,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-jammy-15 main"
+          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
           sudo apt-get -qq update
           sudo apt-get -y install make ${{matrix.config.cc}} ${{matrix.config.cxx}}
           wget --quiet https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-Linux-x86_64.tar.gz
@@ -354,7 +354,7 @@ jobs:
         shell: bash
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-jammy-15 main"
+          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
           sudo apt-get update
           sudo apt-get -qq install clang-15 libtbb-dev
 
@@ -411,7 +411,7 @@ jobs:
         shell: bash
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-jammy-15 main"
+          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
           sudo apt-get update
           sudo apt-get -qq install clang-15 clang-tidy-15
 
@@ -434,7 +434,7 @@ jobs:
         shell: bash
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-jammy-15 main"
+          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
           sudo apt-get -qq install clang-15 libc++1-15 libc++-15-dev libc++abi1-15 libc++abi-15-dev llvm-15-dev libclang-15-dev
           git clone https://github.com/include-what-you-use/include-what-you-use.git
           mkdir include-what-you-use/build && pushd include-what-you-use/build
@@ -462,7 +462,7 @@ jobs:
         shell: bash
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-jammy-15 main"
+          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
           sudo apt-get update
           sudo apt-get -qq install clang-15 libc++1-15 libc++abi1-15 libc++-15-dev libc++abi-15-dev
 
@@ -495,7 +495,7 @@ jobs:
         shell: bash
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-jammy-15 main"
+          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
           sudo apt-get -qq install clang-15 libc++1-15 libc++abi1-15 libc++-15-dev libc++abi-15-dev
 
       - name: Configure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,31 +16,31 @@ jobs:
         build_type: ["Debug", "RelWithDebInfo", "Release"]
         config:
           - {
-            os: ubuntu-latest,
+            os: ubuntu-18.04,  # Note: GCC-7 is gone in Ubuntu-22
             cc: "gcc-7", cxx: "g++-7"
           }
           - {
-            os: ubuntu-latest,
-            cc: "gcc-11", cxx: "g++-11"
+            os: ubuntu-22.04,
+            cc: "gcc-12", cxx: "g++-12"
           }
           - {
             os: ubuntu-18.04,
             cc: "clang-6.0", cxx: "clang++-6.0"
           }
           - {
-            os: ubuntu-latest,
-            cc: "clang-13", cxx: "clang++-13"
+            os: ubuntu-22.04,
+            cc: "clang-15", cxx: "clang++-15"
           }
           - {
-            os: ubuntu-latest,
-            cc: "clang-13", cxx: "clang++-13",
+            os: ubuntu-22.04,
+            cc: "clang-15", cxx: "clang++-15",
             libcxx: true,
-            libcxx_version: 13,
+            libcxx_version: 15,
             note: " with libc++"
           }
           - {
             os: macos-latest,
-            cc: "gcc-11", cxx: "g++-11"
+            cc: "gcc-12", cxx: "g++-12"
           }
           - {
             os: macos-latest,
@@ -52,14 +52,14 @@ jobs:
 
       - name: Set up toolchain repositories
         run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           if [[ "${{ matrix.config.os }}" == "ubuntu-18.04" ]]; then
-            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
             sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main"
-          elif [[ "${{ matrix.config.os }}" == "ubuntu-latest" ]]; then
-            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-            sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
+          elif [[ "${{ matrix.config.os }}" == "ubuntu-20.04" ]]; then
+            sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main"
+          elif [[ "${{ matrix.config.os }}" == "ubuntu-22.04" ]]; then
+            sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-jammy-15 main"
           fi
 
       - name: Install Compiler
@@ -117,10 +117,10 @@ jobs:
     strategy:
       matrix:
         config:
-          - { cc: "gcc-11", cxx: "g++-11" }
-          - { cc: "clang-13", cxx: "clang++-13" }
+          - { cc: "gcc-12", cxx: "g++-12" }
+          - { cc: "clang-15", cxx: "clang++-15" }
 
-    name: windows-2019 WSL ${{ matrix.config.cxx }} (Debug)
+    name: windows-2019 WSL Ubuntu 22.04 ${{ matrix.config.cxx }} (Debug)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: windows-2019
     defaults:
@@ -130,13 +130,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Vampire/setup-wsl@v1
         with:
-          distribution: Ubuntu-20.04
+          distribution: Ubuntu-22.04
 
       - name: Install
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
+          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-jammy-15 main"
           sudo apt-get -qq update
           sudo apt-get -y install make ${{matrix.config.cc}} ${{matrix.config.cxx}}
           wget --quiet https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-Linux-x86_64.tar.gz
@@ -270,23 +270,23 @@ jobs:
           ctest -C Debug --no-tests=error --output-on-failure
 
   opencilk:
-    name: ubuntu-latest Open Cilk 2.0 (Clang 14) (Debug)
+    name: ubuntu-22.04 Open Cilk 2.0.0 (Clang 14) (Debug)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
       - name: Install OpenCilk
         shell: bash
         run: |
-          sudo apt-get -qq install gcc-7 g++-7
+          sudo apt-get -qq install gcc g++
           git clone https://github.com/OpenCilk/cilkrts.git
           mkdir cilkrts/build && pushd cilkrts/build
-          cmake -DCMAKE_C_COMPILER=gcc-7 -DCMAKE_CXX_COMPILER=g++-7 -DCMAKE_INSTALL_PREFIX=/usr/local/ ..
+          cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=/usr/local/ ..
           make && sudo make install
           popd
-          wget --quiet https://github.com/OpenCilk/opencilk-project/releases/download/opencilk%2Fv2.0/OpenCilk-2.0.0-x86_64-Linux-Ubuntu-20.04.tar.gz
-          tar -xf OpenCilk-2.0.0-x86_64-Linux-Ubuntu-20.04.tar.gz
+          wget --quiet https://github.com/OpenCilk/opencilk-project/releases/download/opencilk%2Fv2.0/OpenCilk-2.0.0-x86_64-Linux-Ubuntu-22.04.tar.gz
+          tar -xf OpenCilk-2.0.0-x86_64-Linux-Ubuntu-22.04.tar.gz
 
       - name: Configure
         shell: bash
@@ -307,7 +307,7 @@ jobs:
           ctest -C Debug --no-tests=error --output-on-failure
 
   omp:
-    name: ubuntu-latest OpenMP Clang 13 (Debug)
+    name: ubuntu-22.04 OpenMP Clang 15 (Debug)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
@@ -317,15 +317,15 @@ jobs:
         shell: bash
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
+          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
           sudo apt-get update
-          sudo apt-get -qq install clang-13 libomp-13-dev
+          sudo apt-get -qq install clang-15 libomp-15-dev
 
       - name: Configure
         shell: bash
         run: |
           mkdir build && cd build
-          CC=clang-13 CXX=clang++-13 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DPARLAY_NO_TEST_SCHEDULER=True -DCMAKE_CXX_FLAGS="-fopenmp -DPARLAY_OPENMP" -DCMAKE_EXE_LINKER_FLAGS="-fopenmp" DPARLAY_BENCHMARK=On -DPARLAY_EXAMPLES=On ..
+          CC=clang-15 CXX=clang++-15 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DPARLAY_NO_TEST_SCHEDULER=True -DCMAKE_CXX_FLAGS="-fopenmp -DPARLAY_OPENMP" -DCMAKE_EXE_LINKER_FLAGS="-fopenmp" DPARLAY_BENCHMARK=On -DPARLAY_EXAMPLES=On ..
 
       - name: Build
         shell: bash
@@ -340,9 +340,9 @@ jobs:
           ctest -C Debug --no-tests=error --output-on-failure
 
   tbb:
-    name: ubuntu-latest TBB Clang 13 (Debug)
+    name: ubuntu-22.04 TBB Clang 15 (Debug)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
@@ -350,15 +350,15 @@ jobs:
         shell: bash
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
+          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-jammy-15 main"
           sudo apt-get update
-          sudo apt-get -qq install clang-13 libtbb-dev
+          sudo apt-get -qq install clang-15 libtbb-dev
 
       - name: Configure
         shell: bash
         run: |
           mkdir build && cd build
-          CC=clang-13 CXX=clang++-13 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DPARLAY_NO_TEST_SCHEDULER=True -DCMAKE_CXX_FLAGS="-DPARLAY_TBB" -DCMAKE_EXE_LINKER_FLAGS="-ltbb" DPARLAY_BENCHMARK=On -DPARLAY_EXAMPLES=On ..
+          CC=clang-15 CXX=clang++-15 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DPARLAY_NO_TEST_SCHEDULER=True -DCMAKE_CXX_FLAGS="-DPARLAY_TBB" -DCMAKE_EXE_LINKER_FLAGS="-ltbb" DPARLAY_BENCHMARK=On -DPARLAY_EXAMPLES=On ..
 
       - name: Build
         shell: bash
@@ -375,16 +375,16 @@ jobs:
   cppcheck:
     name: Cppcheck
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
       - name: Install Cppcheck
         shell: bash
         run: |
-          wget --quiet https://github.com/danmar/cppcheck/archive/refs/tags/2.8.tar.gz
-          tar -xf 2.8.tar.gz
-          mkdir cppcheck-2.8/build && pushd cppcheck-2.8/build
+          wget --quiet https://github.com/danmar/cppcheck/archive/2.10.tar.gz
+          tar -xf 2.10.tar.gz
+          mkdir cppcheck-2.10/build && pushd cppcheck-2.10/build
           cmake .. -DCMAKE_BUILD_TYPE=Release
           make && sudo make install
           popd
@@ -399,7 +399,7 @@ jobs:
   clang-tidy:
     name: Clang Tidy
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
@@ -407,22 +407,22 @@ jobs:
         shell: bash
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
+          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-jammy-15 main"
           sudo apt-get update
-          sudo apt-get -qq install clang-13 clang-tidy-13
+          sudo apt-get -qq install clang-15 clang-tidy-15
 
       - name: Run Clang Tidy
         shell: bash
         run: |
           mkdir build
           cd build
-          CC=clang-13 CXX=clang++-13 cmake -DENABLE_CLANG_TIDY=On -DCLANG_TIDY_EXE=/usr/bin/clang-tidy-13 ..
+          CC=clang-15 CXX=clang++-15 cmake -DENABLE_CLANG_TIDY=On -DCLANG_TIDY_EXE=/usr/bin/clang-tidy-15 ..
           make clang-tidy-all
 
   iwyu:
     name: Include-what-you-use
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
@@ -430,12 +430,12 @@ jobs:
         shell: bash
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
-          sudo apt-get -qq install clang-13 libc++1-13 libc++-13-dev libc++abi1-13 libc++abi-13-dev llvm-13-dev libclang-13-dev
+          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-jammy-15 main"
+          sudo apt-get -qq install clang-15 libc++1-15 libc++-15-dev libc++abi1-15 libc++abi-15-dev llvm-15-dev libclang-15-dev
           git clone https://github.com/include-what-you-use/include-what-you-use.git
           mkdir include-what-you-use/build && pushd include-what-you-use/build
-          git checkout clang_13
-          cmake -DCMAKE_PREFIX_PATH=/usr/lib/llvm-13 ..
+          git checkout clang_15
+          cmake -DCMAKE_PREFIX_PATH=/usr/lib/llvm-15 ..
           make && sudo make install
           popd
 
@@ -444,14 +444,13 @@ jobs:
         run: |
           mkdir build
           cd build
-          CC=clang-13 CXX=clang++-13 cmake -DENABLE_IWYU=On ..
+          CC=clang-15 CXX=clang++-15 cmake -DENABLE_IWYU=On ..
           make iwyu-all
 
   asan:
-    # Running with old Clang 10 because GoogleTest triggers ASAN on Clang 13 for some reason
-    name: ubuntu-latest ASAN Clang 10 (Debug)
+    name: ubuntu-22.04 ASAN Clang 15 (Debug)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
@@ -459,15 +458,15 @@ jobs:
         shell: bash
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
+          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-jammy-15 main"
           sudo apt-get update
-          sudo apt-get -qq install clang-10 libc++1-10 libc++abi1-10 libc++-10-dev libc++abi-10-dev
+          sudo apt-get -qq install clang-15 libc++1-15 libc++abi1-15 libc++-15-dev libc++abi-15-dev
 
       - name: Configure
         shell: bash
         run: |
           mkdir build && cd build
-          CC=clang-10 CXX=clang++-10 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DBUILD_ASAN_TESTS=On -DBUILD_ONLY_SANITIZED=True -DUSE_LIBCXX=True ..
+          CC=clang-15 CXX=clang++-15 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DBUILD_ASAN_TESTS=On -DBUILD_ONLY_SANITIZED=True -DUSE_LIBCXX=True ..
 
       - name: Build
         shell: bash
@@ -482,9 +481,9 @@ jobs:
           ctest -C Debug --no-tests=error --output-on-failure -R asan
 
   ubsan:
-    name: ubuntu-latest UBSAN Clang 13 (Debug)
+    name: ubuntu-22.04 UBSAN Clang 15 (Debug)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
@@ -492,14 +491,14 @@ jobs:
         shell: bash
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
-          sudo apt-get -qq install clang-13 libc++1-13 libc++abi1-13 libc++-13-dev libc++abi-13-dev
+          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-jammy-15 main"
+          sudo apt-get -qq install clang-15 libc++1-15 libc++abi1-15 libc++-15-dev libc++abi-15-dev
 
       - name: Configure
         shell: bash
         run: |
           mkdir build && cd build
-          CC=clang-13 CXX=clang++-13 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DBUILD_UBSAN_TESTS=On -DBUILD_ONLY_SANITIZED=True -DUSE_LIBCXX=True ..
+          CC=clang-15 CXX=clang++-15 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DBUILD_UBSAN_TESTS=On -DBUILD_ONLY_SANITIZED=True -DUSE_LIBCXX=True ..
 
       - name: Build
         shell: bash
@@ -516,7 +515,7 @@ jobs:
   coverage:
     name: Test Coverage
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       - uses: actions/checkout@v2
@@ -524,13 +523,13 @@ jobs:
       - name: Install LCov
         shell: bash
         run: |
-          sudo apt-get -qq install gcc-9 g++-9 lcov
+          sudo apt-get -qq install gcc-12 g++-12 lcov
 
       - name: Configure
         shell: bash
         run: |
           mkdir build && cd build
-          CC=gcc-9 CXX=g++-9 cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG=" --coverage " -DPARLAY_TEST=On ..
+          CC=gcc-12 CXX=g++-12 cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG=" --coverage " -DPARLAY_TEST=On ..
 
       - name: Build
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,13 +52,17 @@ jobs:
 
       - name: Set up toolchain repositories
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           if [[ "${{ matrix.config.os }}" == "ubuntu-18.04" ]]; then
+            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
             sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main"
           elif [[ "${{ matrix.config.os }}" == "ubuntu-20.04" ]]; then
+            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
             sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main"
           elif [[ "${{ matrix.config.os }}" == "ubuntu-22.04" ]]; then
+            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
             sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-jammy-15 main"
           fi
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ if (PARLAY_BENCHMARK)
   include(FetchContent)
   FetchContent_Declare(benchmark
     GIT_REPOSITORY  https://github.com/google/benchmark.git
-    GIT_TAG         v1.6.2
+    GIT_TAG         v1.7.1
   )
   FetchContent_GetProperties(benchmark)
   if(NOT benchmark_POPULATED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # -------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 3.14)
-project(PARLAY VERSION 2.1.2
+project(PARLAY VERSION 2.1.3
         DESCRIPTION "A collection of parallel algorithms and other support for parallelism in C++"
         LANGUAGES CXX)
 

--- a/include/parlay/alloc.h
+++ b/include/parlay/alloc.h
@@ -171,7 +171,7 @@ struct allocator {
     }
   }
 
-  constexpr allocator() noexcept { internal::get_default_allocator(); };
+  constexpr allocator() { internal::get_default_allocator(); };
   template <class U> /* implicit */ constexpr allocator(const allocator<U>&) noexcept { }
 };
 

--- a/include/parlay/internal/scheduler_plugins/tbb.h
+++ b/include/parlay/internal/scheduler_plugins/tbb.h
@@ -3,6 +3,8 @@
 
 #include <cstddef>
 
+#include <type_traits>
+
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_invoke.h>
@@ -13,33 +15,38 @@ namespace parlay {
 // IWYU pragma: private, include "../../parallel.h"
 
 inline size_t num_workers() { return tbb::this_task_arena::max_concurrency(); }
-inline size_t worker_id() { return tbb::task_arena::current_thread_index(); }
 
-template <class F>
-inline void parallel_for(size_t start, size_t end, F f, long granularity, bool) {
-  if (end > start) {
-    if (granularity == 0) {
-      tbb::parallel_for(tbb::blocked_range<size_t>(start, end), [&](const tbb::blocked_range<size_t>& r) {
-        for (auto i = r.begin(); i != r.end(); ++i) {
-          f(i);
-        }
-      });
-    }
-    else {
-      size_t n_blocks = (end - start + granularity - 1) / granularity;
-      size_t block_size = (end - start + n_blocks - 1) / n_blocks;
-      tbb::parallel_for(size_t{0}, n_blocks, [&](size_t b) {
-        for (size_t i = b * block_size + start; i < (b + 1) * block_size + start && i < end; i++) {
-          f(i);
-        }
-      });
-    }
+inline size_t worker_id() {
+  auto id = tbb::this_task_arena::current_thread_index();
+  return id == tbb::task_arena::not_initialized ? 0 : id;
+}
+
+template <typename F>
+inline void parallel_for(size_t start, size_t end, F&& f, long granularity, bool) {
+  static_assert(std::is_invocable_v<F&, size_t>);
+  // Use TBB's automatic granularity partitioner (tbb::auto_partitioner)
+  if (granularity == 0) {
+    tbb::parallel_for(tbb::blocked_range<size_t>(start, end), [&](const tbb::blocked_range<size_t>& r) {
+      for (auto i = r.begin(); i != r.end(); ++i) {
+        f(i);
+      }
+    }, tbb::auto_partitioner{});
+  }
+  // Otherwise, use the granularity specified by the user (tbb::simple_partitioner)
+  else {
+    tbb::parallel_for(tbb::blocked_range<size_t>(start, end, granularity), [&](const tbb::blocked_range<size_t>& r) {
+      for (auto i = r.begin(); i != r.end(); ++i) {
+        f(i);
+      }
+    }, tbb::simple_partitioner{});
   }
 }
 
 template <typename Lf, typename Rf>
-inline void par_do(Lf left, Rf right, bool) {
-  tbb::parallel_invoke(left, right);
+inline void par_do(Lf&& left, Rf&& right, bool) {
+  static_assert(std::is_invocable_v<Lf&&>);
+  static_assert(std::is_invocable_v<Rf&&>);
+  tbb::parallel_invoke(std::forward<Lf>(left), std::forward<Rf>(right));
 }
 
 }  // namespace parlay

--- a/include/parlay/internal/scheduler_plugins/tbb.h
+++ b/include/parlay/internal/scheduler_plugins/tbb.h
@@ -22,7 +22,7 @@ inline size_t worker_id() {
 }
 
 template <typename F>
-inline void parallel_for(size_t start, size_t end, F&& f, long granularity, bool) {
+inline void parallel_for(size_t start, size_t end, F f, long granularity, bool) {
   static_assert(std::is_invocable_v<F&, size_t>);
   // Use TBB's automatic granularity partitioner (tbb::auto_partitioner)
   if (granularity == 0) {
@@ -43,7 +43,7 @@ inline void parallel_for(size_t start, size_t end, F&& f, long granularity, bool
 }
 
 template <typename Lf, typename Rf>
-inline void par_do(Lf&& left, Rf&& right, bool) {
+inline void par_do(Lf left, Rf right, bool) {
   static_assert(std::is_invocable_v<Lf&&>);
   static_assert(std::is_invocable_v<Rf&&>);
   tbb::parallel_invoke(std::forward<Lf>(left), std::forward<Rf>(right));


### PR DESCRIPTION
GitHub Actions upgrading to Ubuntu 22 broke a few things because of version differences/incompatibilities. This fixes them, and now hardcodes all of the Ubuntu jobs to specify a specific version, .e.g, `ubuntu-22.04` and never use `ubuntu-latest`, to prevent this in the future.  In the future we should manually upgrade things whenever a new Ubuntu LTS is available.

- Fixes PR #24, which broke because a newer version of TBB removed a deprecated function that we were using
- Uses a newer version of Google Benchmark which no longer spams error messages during configuration