### PR TITLE
sequential schedule plugin fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -380,6 +380,38 @@ jobs:
           cd build
           ctest -C Debug --no-tests=error --output-on-failure
 
+  sequential:
+    name: ubuntu-22.04 Sequential GCC 12 (Debug)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Compiler
+        shell: bash
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get -qq install gcc-12 g++-12
+
+      - name: Configure
+        shell: bash
+        run: |
+          mkdir build && cd build
+          CC=gcc-12 CXX=g++-12 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DPARLAY_SEQUENTIAL=On DPARLAY_BENCHMARK=On -DPARLAY_EXAMPLES=On ..
+
+      - name: Build
+        shell: bash
+        run: |
+          cd build
+          cmake --build . --config Debug
+
+      - name: Test
+        shell: bash
+        run: |
+          cd build
+          ctest -C Debug --no-tests=error --output-on-failure
+
   cppcheck:
     name: Cppcheck
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # -------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 3.14)
-project(PARLAY VERSION 2.1.4
+project(PARLAY VERSION 2.1.5
         DESCRIPTION "A collection of parallel algorithms and other support for parallelism in C++"
         LANGUAGES CXX)
 
@@ -233,7 +233,7 @@ endif()
 
 message(STATUS "------------------- Examples --------------------")
 
-# User option to build benchmarks
+# User option to build examples
 option(PARLAY_EXAMPLES    "Build examples"  OFF)
 
 if (PARLAY_EXAMPLES)

--- a/include/parlay/internal/scheduler_plugins/sequential.h
+++ b/include/parlay/internal/scheduler_plugins/sequential.h
@@ -17,7 +17,7 @@ inline void set_num_workers(int) { }
 #endif
 
 template <class F>
-inline void parallel_for(size_t start, size_t end, F f, long, bool) {
+inline void parallel_for(size_t start, size_t end, F&& f, long, bool) {
   for (size_t i=start; i<end; i++) {
     f(i);
   }
@@ -28,7 +28,7 @@ inline void parallel_for(size_t start, size_t end, F f, long, bool) {
 #endif
 
 template <typename Lf, typename Rf>
-inline void par_do(Lf left, Rf right, bool) {
+inline void par_do(Lf&& left, Rf&& right, bool) {
   left(); right();
 }
 

--- a/include/parlay/internal/scheduler_plugins/sequential.h
+++ b/include/parlay/internal/scheduler_plugins/sequential.h
@@ -29,7 +29,8 @@ inline void parallel_for(size_t start, size_t end, F&& f, long, bool) {
 
 template <typename Lf, typename Rf>
 inline void par_do(Lf&& left, Rf&& right, bool) {
-  left(); right();
+  std::forward<Lf>(left)();
+  std::forward<Rf>(right)();
 }
 
 }  // namespace parlay


### PR DESCRIPTION
Forwarding the lambda argument for the sequential schedule plugin

Without the change I was getting compile errors like the following

```
In file included from run.cpp:1:
In file included from ./CPMA.hpp:58:
In file included from ./parlaylib/include/parlay/primitives.h:18:
In file included from ./parlaylib/include/parlay/internal/counting_sort.h:15:
In file included from ./parlaylib/include/parlay/internal/sequence_ops.h:16:
In file included from ./parlaylib/include/parlay/internal/../sequence.h:29:
In file included from ./parlaylib/include/parlay/alloc.h:20:
./parlaylib/include/parlay/internal/block_allocator.h:86:5: error: call to 'parallel_for' is ambiguous
    parallel_for (0, list_length - 1, [&] (size_t i) {
    ^~~~~~~~~~~~
./parlaylib/include/parlay/internal/concurrency/../../parallel.h:38:13: note: candidate function [with F = (lambda at ./parlaylib/include/parlay/internal/block_allocator.h:86:39)]
inline void parallel_for(size_t start, size_t end, F&& f, long granularity = 0,
            ^
./parlaylib/include/parlay/internal/scheduler_plugins/sequential.h:20:13: note: candidate function [with F = (lambda at ./parlaylib/include/parlay/internal/block_allocator.h:86:39)]
inline void parallel_for(size_t start, size_t end, F f, long, bool) {
```

Changing it to match the rest of the plugins fixed the compile issue for me. Only tested that it compiled 