### PR TITLE
Elastic scheduler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -380,6 +380,38 @@ jobs:
           cd build
           ctest -C Debug --no-tests=error --output-on-failure
 
+  sequential:
+    name: ubuntu-22.04 Sequential GCC 12 (Debug)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Compiler
+        shell: bash
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get -qq install gcc-12 g++-12
+
+      - name: Configure
+        shell: bash
+        run: |
+          mkdir build && cd build
+          CC=gcc-12 CXX=g++-12 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DPARLAY_SEQUENTIAL=On DPARLAY_BENCHMARK=On -DPARLAY_EXAMPLES=On ..
+
+      - name: Build
+        shell: bash
+        run: |
+          cd build
+          cmake --build . --config Debug
+
+      - name: Test
+        shell: bash
+        run: |
+          cd build
+          ctest -C Debug --no-tests=error --output-on-failure
+
   cppcheck:
     name: Cppcheck
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,35 +248,35 @@ jobs:
 #          cd build
 #          ctest -C Debug --no-tests=error --output-on-failure
 
-  cilk-plus:
-    name: ubuntu-18.04 Cilk Plus GCC-7 (Debug)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-18.04   # Note: GCC-7 on Ubuntu-20 removed Cilk Plus, so we have to go back in time
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install GCC-7
-        shell: bash
-        run: |
-          sudo apt-get -qq install gcc-7 g++-7
-
-      - name: Configure
-        shell: bash
-        run: |
-          mkdir build && cd build
-          CC=gcc-7 CXX=g++-7 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DPARLAY_CILKPLUS=On -DPARLAY_BENCHMARK=On -DPARLAY_EXAMPLES=On ..
-
-      - name: Build
-        shell: bash
-        run: |
-          cd build
-          cmake --build . --config Debug
-
-      - name: Test
-        shell: bash
-        run: |
-          cd build
-          ctest -C Debug --no-tests=error --output-on-failure
+#  cilk-plus:
+#    name: ubuntu-18.04 Cilk Plus GCC-7 (Debug)
+#    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+#    runs-on: ubuntu-18.04   # Note: GCC-7 on Ubuntu-20 removed Cilk Plus, so we have to go back in time
+#    steps:
+#      - uses: actions/checkout@v2
+#
+#      - name: Install GCC-7
+#        shell: bash
+#        run: |
+#          sudo apt-get -qq install gcc-7 g++-7
+#
+#      - name: Configure
+#        shell: bash
+#        run: |
+#          mkdir build && cd build
+#          CC=gcc-7 CXX=g++-7 cmake -DCMAKE_BUILD_TYPE=Debug -DPARLAY_TEST=On -DPARLAY_CILKPLUS=On -DPARLAY_BENCHMARK=On -DPARLAY_EXAMPLES=On ..
+#
+#      - name: Build
+#        shell: bash
+#        run: |
+#          cd build
+#          cmake --build . --config Debug
+#
+#      - name: Test
+#        shell: bash
+#        run: |
+#          cd build
+#          ctest -C Debug --no-tests=error --output-on-failure
 
   opencilk:
     name: ubuntu-22.04 OpenCilk 2.0.0 (Clang 15) (Debug)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         build_type: ["Debug", "RelWithDebInfo", "Release"]
         config:
           - {
-            os: ubuntu-18.04,  # Note: GCC-7 is gone in Ubuntu-22
+            os: ubuntu-20.04,  # Note: GCC-7 is gone in Ubuntu-22
             cc: "gcc-7", cxx: "g++-7"
           }
           - {
@@ -26,7 +26,7 @@ jobs:
             cc: "gcc-12", cxx: "g++-12"
           }
           - {
-            os: ubuntu-18.04,
+            os: ubuntu-20.04,
             cc: "clang-6.0", cxx: "clang++-6.0"
           }
           - {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ else()
 endif()
 
 message(STATUS "PARLAY VERSION ${PARLAY_VERSION}")
-message(STATUS "--------------- General configuration -------------")
+message(STATUS "---------------------------- General configuration -----------------------------")
 message(STATUS "CMake Generator:                ${CMAKE_GENERATOR}")
 message(STATUS "Compiler:                       ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
 message(STATUS "Build type:                     ${CMAKE_BUILD_TYPE}")
@@ -55,6 +55,14 @@ target_compile_features(parlay INTERFACE cxx_std_17)
 # Link against system threads
 find_package(Threads REQUIRED)
 target_link_libraries(parlay INTERFACE Threads::Threads)
+
+
+message(STATUS "-------------------------------- Library options ------------------------------")
+
+# -------------------------------------------------------------------
+#                Enable/disable elastic parallelism
+
+option(PARLAY_ELASTIC_PARALLELISM "Enable elastic parallelism" On)
 
 # -------------------------------------------------------------------
 #              Support for alternative parallel runtimes
@@ -111,6 +119,20 @@ elseif(PARLAY_TBB)
 elseif(PARLAY_SEQUENTIAL)
   message(STATUS "Parlay sequential mode enabled (no parallelism!!)")
   target_compile_definitions(parlay INTERFACE PARLAY_SEQUENTIAL)
+else()
+  message(STATUS "Using Parlay scheduler. Switch with -DPARLAY_{CILKPLUS,OPENCILK,OPENMP,TBB}=On")
+  if (PARLAY_ELASTIC_PARALLELISM)
+    message(STATUS "Elastic parallelism enabled. Disable with -DPARLAY_ELASTIC_PARALLELISM=Off")
+    target_compile_definitions(parlay INTERFACE PARLAY_ELASTIC_PARALLELISM=true)
+    
+    # On Windows we need to link against synchronization.lib for WaitOnAddress
+    if (WIN32)
+      target_link_libraries(parlay INTERFACE synchronization)
+    endif()
+  else()
+    message(STATUS "Elastic parallelism disabled. Enable with -DPARLAY_ELASTIC_PARALLELISM=On")
+    target_compile_definitions(parlay INTERFACE PARLAY_ELASTIC_PARALLELISM=false)
+  endif()
 endif()
 
 
@@ -148,13 +170,13 @@ install(DIRECTORY ${PARLAY_INCLUDE_DIR}/parlay DESTINATION include)
 # -------------------------------------------------------------------
 #                       Static analysis
 
-message(STATUS "-------------------------- Static Analysis ------------------------")
+message(STATUS "------------------------------- Static Analysis --------------------------------")
 add_subdirectory(analysis)
 
 # -------------------------------------------------------------------
 #                         Unit tests
 
-message(STATUS "-------------------------- Unit Tests ------------------------")
+message(STATUS "---------------------------------- Unit Tests ----------------------------------")
 
 # User option to build unit tests
 option(PARLAY_TEST  "Build unit tests"       OFF)
@@ -194,7 +216,7 @@ endif()
 # -------------------------------------------------------------------
 #                       Benchmarks
 
-message(STATUS "------------------- Benchmarks --------------------")
+message(STATUS "---------------------------------- Benchmarks ----------------------------------")
 
 # User option to build benchmarks
 option(PARLAY_BENCHMARK    "Build microbenchmarks"  OFF)
@@ -231,7 +253,7 @@ endif()
 # -------------------------------------------------------------------
 #                          Examples
 
-message(STATUS "------------------- Examples --------------------")
+message(STATUS "----------------------------------- Examples -----------------------------------")
 
 # User option to build examples
 option(PARLAY_EXAMPLES    "Build examples"  OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # -------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 3.14)
-project(PARLAY VERSION 2.1.4
+project(PARLAY VERSION 2.1.5
         DESCRIPTION "A collection of parallel algorithms and other support for parallelism in C++"
         LANGUAGES CXX)
 
@@ -233,7 +233,7 @@ endif()
 
 message(STATUS "------------------- Examples --------------------")
 
-# User option to build benchmarks
+# User option to build examples
 option(PARLAY_EXAMPLES    "Build examples"  OFF)
 
 if (PARLAY_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # -------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 3.14)
-project(PARLAY VERSION 2.1.6
+project(PARLAY VERSION 2.1.7
         DESCRIPTION "A collection of parallel algorithms and other support for parallelism in C++"
         LANGUAGES CXX)
 

--- a/include/parlay/internal/atomic_wait.h
+++ b/include/parlay/internal/atomic_wait.h
@@ -348,7 +348,7 @@ namespace parlay {
 
     template <class _Tp, class _Tv>
     __ABI void atomic_wait_explicit(std::atomic<_Tp> const* a, _Tv val, std::memory_order order) {
-        __cxx_atomic_wait((const _Tp*)a, (_Tp)val, (int)order);
+        __cxx_atomic_wait((const _Tp*)a, (_Tp)val, (int)order);   // cppcheck-suppress cstyleCast
     }
     template <class _Tp, class _Tv>
     __ABI void atomic_wait(std::atomic<_Tp> const* a, _Tv val) {
@@ -356,11 +356,11 @@ namespace parlay {
     }
     template <class _Tp>
     __ABI void atomic_notify_one(std::atomic<_Tp> const* a) {
-        __cxx_atomic_notify_one((const _Tp*)a);
+        __cxx_atomic_notify_one((const _Tp*)a);                   // cppcheck-suppress cstyleCast
     }
     template <class _Tp>
     __ABI void atomic_notify_all(std::atomic<_Tp> const* a) {
-        __cxx_atomic_notify_all((const _Tp*)a);
+        __cxx_atomic_notify_all((const _Tp*)a);                   // cppcheck-suppress cstyleCast
     }
 
 }

--- a/include/parlay/internal/atomic_wait.h
+++ b/include/parlay/internal/atomic_wait.h
@@ -135,7 +135,16 @@ The strategy is chosen this way, by platform:
     #define __NO_CONDVAR
     #define __NO_TABLE
 
+    
+    #ifndef NOMINMAX
+    #define PARLAY_DEFINED_NOMINMAX
+    #define NOMINMAX
+    #endif
     #include <Windows.h>
+    #ifdef PARLAY_DEFINED_NOMINMAX
+    #undef NOMINMAX
+    #endif
+    
     #define __YIELD() Sleep(0)
     #define __SLEEP(x) Sleep(x)
     #define __YIELD_PROCESSOR() YieldProcessor()

--- a/include/parlay/internal/atomic_wait.h
+++ b/include/parlay/internal/atomic_wait.h
@@ -1,0 +1,401 @@
+// modified from https://raw.githubusercontent.com/ogiroux/atomic_wait/master/include/atomic_wait
+/*
+
+Copyright (c) 2019, NVIDIA Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+/*
+
+This file introduces std::atomic_wait, atomic_notify_one, atomic_notify_all.
+
+It has these strategies implemented:
+ * Contention table. Used to optimize futex notify, or to hold CVs. Disable with __NO_TABLE.
+ * Futex. Supported on Linux and Windows. For performance requires a table on Linux. Disable with __NO_FUTEX.
+ * Condition variables. Supported on Linux and Mac. Requires table to function. Disable with __NO_CONDVAR.
+ * Timed back-off. Supported on everything. Disable with __NO_SLEEP.
+ * Spinlock. Supported on everything. Force with __NO_IDENT. Note: performance is too terrible to use.
+
+You can also compare to pure spinning at algorithm level with __NO_WAIT.
+
+The strategy is chosen this way, by platform:
+ * Linux: default to futex (with table), fallback to futex (no table) -> CVs -> timed backoff -> spin.
+ * Mac: default to CVs (table), fallback to timed backoff -> spin.
+ * Windows: default to futex (no table), fallback to timed backoff -> spin.
+ * CUDA: default to timed backoff, fallback to spin. (This is not all checked in in this tree.)
+ * Unidentified platform: default to spin.
+
+*/
+
+//#define __NO_TABLE
+//#define __NO_FUTEX
+//#define __NO_CONDVAR
+//#define __NO_SLEEP
+//#define __NO_IDENT
+
+// To benchmark against spinning
+//#define __NO_SPIN
+//#define __NO_WAIT
+
+#ifndef __ATOMIC_WAIT_INCLUDED
+#define __ATOMIC_WAIT_INCLUDED
+
+#ifndef __cpp_lib_atomic_wait
+
+#include <cstdint>
+#include <climits>
+#include <cassert>
+#include <type_traits>
+
+#if defined(__NO_IDENT)
+
+    #include <thread>
+    #include <chrono>
+
+    #define __ABI
+    #define __YIELD() std::this_thread::yield()
+    #define __SLEEP(x) std::this_thread::sleep_for(std::chrono::microseconds(x))
+    #define __YIELD_PROCESSOR()
+
+#else
+
+#if defined(__CUSTD__)
+    #define __NO_FUTEX
+    #define __NO_CONDVAR
+    #ifndef __CUDACC__
+        #define __host__
+        #define __device__
+    #endif
+    #define __ABI __host__ __device__
+#else
+    #define __ABI
+#endif
+
+#if defined(__APPLE__) || defined(__linux__)
+
+    #include <unistd.h>
+    #include <sched.h>
+    #define __YIELD() sched_yield()
+    #define __SLEEP(x) usleep(x)
+
+    #if defined(__aarch64__)
+        #  define __YIELD_PROCESSOR() asm volatile ("yield" ::: "memory")
+    #elif defined(__x86_64__)
+        # define __YIELD_PROCESSOR() asm volatile ("pause" ::: "memory")
+    #elif defined (__powerpc__)
+        # define __YIELD_PROCESSOR() asm volatile ("or 27,27,27" ::: "memory")
+    #endif
+#endif
+
+#if defined(__linux__) && !defined(__NO_FUTEX)
+
+    #if !defined(__NO_TABLE)
+        #define __TABLE
+    #endif
+
+    #include <time.h>
+    #include <unistd.h>
+    #include <linux/futex.h>
+    #include <sys/syscall.h>
+
+    #define __FUTEX
+    #define __FUTEX_TIMED
+    #define __type_used_directly(_T) (std::is_same<typename std::remove_const< \
+            typename std::remove_volatile<_Tp>::type>::type, __futex_preferred_t>::value)
+    using __futex_preferred_t = std::int32_t;
+    template <class _Tp, typename std::enable_if<__type_used_directly(_Tp), int>::type = 1>
+    void __do_direct_wait(_Tp const* ptr, _Tp val, void const* timeout) {
+        syscall(SYS_futex, ptr, FUTEX_WAIT_PRIVATE, val, timeout, 0, 0);
+    }
+    template <class _Tp, typename std::enable_if<__type_used_directly(_Tp), int>::type = 1>
+    void __do_direct_wake(_Tp const* ptr, bool all) {
+        syscall(SYS_futex, ptr, FUTEX_WAKE_PRIVATE, all ? INT_MAX : 1, 0, 0, 0);
+    }
+
+#elif defined(_WIN32) && !defined(__CUSTD__)
+
+    #define __NO_CONDVAR
+    #define __NO_TABLE
+
+    #include <Windows.h>
+    #define __YIELD() Sleep(0)
+    #define __SLEEP(x) Sleep(x)
+    #define __YIELD_PROCESSOR() YieldProcessor()
+
+    #include <intrin.h>
+    template <class _Tp>
+    auto __atomic_load_n(_Tp const* a, int) -> typename std::remove_reference<decltype(*a)>::type {
+        auto const t = *a;
+        _ReadWriteBarrier();
+        return t;
+    }
+    #define __builtin_expect(e, v) (e)
+
+    #if defined(_WIN32_WINNT) && (_WIN32_WINNT >= _WIN32_WINNT_WIN8) && !defined(__NO_FUTEX)
+
+        #define __FUTEX
+        #define __type_used_directly(_T) (sizeof(_T) <= 8)
+        using __futex_preferred_t = std::int64_t;
+        template <class _Tp, typename std::enable_if<__type_used_directly(_Tp), int>::type = 1>
+        void __do_direct_wait(_Tp const* ptr, _Tp val, void const*) {
+            WaitOnAddress((PVOID)ptr, (PVOID)&val, sizeof(_Tp), INFINITE);
+        }
+        template <class _Tp, typename std::enable_if<__type_used_directly(_Tp), int>::type = 1>
+        void __do_direct_wake(_Tp const* ptr, bool all) {
+            if (all)
+                WakeByAddressAll((PVOID)ptr);
+            else
+                WakeByAddressSingle((PVOID)ptr);
+        }
+
+    #endif
+#endif // _WIN32
+
+#if !defined(__FUTEX) && !defined(__NO_CONDVAR)
+
+    #if defined(__NO_TABLE)
+        #warning "Condvars always generate a table (ignoring __NO_TABLE)."
+    #endif
+    #include <pthread.h>
+    #define __CONDVAR
+    #define __TABLE
+#endif
+
+#endif // __NO_IDENT
+
+#ifdef __TABLE
+    struct alignas(64) contended_t {
+    #if defined(__FUTEX)
+        int                     waiters = 0;
+        __futex_preferred_t     version = 0;
+    #elif defined(__CONDVAR)
+        int                     credit = 0;
+        pthread_mutex_t         mutex = PTHREAD_MUTEX_INITIALIZER;
+        pthread_cond_t          condvar = PTHREAD_COND_INITIALIZER;
+    #else
+        #error ""
+    #endif
+    };
+    contended_t * __contention(volatile void const * p);
+#else
+    template <class _Tp>
+    __ABI void __cxx_atomic_try_wait_slow_fallback(_Tp const* ptr, _Tp val, int order) {
+    #ifndef __NO_SLEEP
+        long history = 10;
+        do {
+            __SLEEP(history >> 2);
+            history += history >> 2;
+            if (history > (1 << 10))
+                history = 1 << 10;
+        } while (__atomic_load_n(ptr, order) == val);
+    #else
+        __YIELD();
+    #endif
+    }
+#endif // __TABLE
+
+#if defined(__CONDVAR)
+
+    template <class _Tp>
+    void __cxx_atomic_notify_all(volatile _Tp const* ptr) {
+        auto * const c = __contention(ptr);
+        __atomic_thread_fence(__ATOMIC_SEQ_CST);
+        if(__builtin_expect(0 == __atomic_load_n(&c->credit, __ATOMIC_RELAXED), 1))
+            return;
+        if(0 != __atomic_exchange_n(&c->credit, 0, __ATOMIC_RELAXED)) {
+            pthread_mutex_lock(&c->mutex);
+            pthread_mutex_unlock(&c->mutex);
+            pthread_cond_broadcast(&c->condvar);
+        }
+    }
+    template <class _Tp>
+    void __cxx_atomic_notify_one(volatile _Tp const* ptr) {
+        __cxx_atomic_notify_all(ptr);
+    }
+    template <class _Tp>
+    void __cxx_atomic_try_wait_slow(volatile _Tp const* ptr, _Tp const val, int order) {
+        auto * const c = __contention(ptr);
+        pthread_mutex_lock(&c->mutex);
+        __atomic_store_n(&c->credit, 1, __ATOMIC_RELAXED);
+        __atomic_thread_fence(__ATOMIC_SEQ_CST);
+        if (val == __atomic_load_n(ptr, order))
+            pthread_cond_wait(&c->condvar, &c->mutex);
+        pthread_mutex_unlock(&c->mutex);
+    }
+
+#elif defined(__FUTEX)
+
+        template <class _Tp, typename std::enable_if<!__type_used_directly(_Tp), int>::type = 1>
+        void __cxx_atomic_notify_all(_Tp const* ptr) {
+    #if defined(__TABLE)
+            auto * const c = __contention(ptr);
+            __atomic_fetch_add(&c->version, 1, __ATOMIC_RELAXED);
+            __atomic_thread_fence(__ATOMIC_SEQ_CST);
+            if (0 != __atomic_exchange_n(&c->waiters, 0, __ATOMIC_RELAXED))
+                __do_direct_wake(&c->version, true);
+    #endif
+        }
+        template <class _Tp, typename std::enable_if<!__type_used_directly(_Tp), int>::type = 1>
+        void __cxx_atomic_notify_one(_Tp const* ptr) {
+            __cxx_atomic_notify_all(ptr);
+        }
+        template <class _Tp, typename std::enable_if<!__type_used_directly(_Tp), int>::type = 1>
+        void __cxx_atomic_try_wait_slow(_Tp const* ptr, _Tp const val, int order) {
+    #if defined(__TABLE)
+            auto * const c = __contention(ptr);
+            __atomic_store_n(&c->waiters, 1, __ATOMIC_RELAXED);
+            __atomic_thread_fence(__ATOMIC_SEQ_CST);
+            auto const version = __atomic_load_n(&c->version, __ATOMIC_RELAXED);
+            if (__builtin_expect(val != __atomic_load_n(ptr, order), 1))
+                return;
+        #ifdef __FUTEX_TIMED
+            constexpr timespec timeout = { 2, 0 }; // Hedge on rare 'int version' aliasing.
+            __do_direct_wait(&c->version, version, &timeout);
+        #else
+            __do_direct_wait(&c->version, version, nullptr);
+        #endif
+    #else
+        __cxx_atomic_try_wait_slow_fallback(ptr, val, order);
+    #endif // __TABLE
+        }
+
+    template <class _Tp, typename std::enable_if<__type_used_directly(_Tp), int>::type = 1>
+    void __cxx_atomic_try_wait_slow(_Tp const* ptr, _Tp val, int order) {
+    #ifdef __TABLE
+        auto * const c = __contention(ptr);
+        __atomic_fetch_add(&c->waiters, 1, __ATOMIC_RELAXED);
+        __atomic_thread_fence(__ATOMIC_SEQ_CST);
+    #endif
+        __do_direct_wait(ptr, val, nullptr);
+    #ifdef __TABLE
+        __atomic_fetch_sub(&c->waiters, 1, __ATOMIC_RELAXED);
+    #endif
+    }
+    template <class _Tp, typename std::enable_if<__type_used_directly(_Tp), int>::type = 1>
+    void __cxx_atomic_notify_all(_Tp const* ptr) {
+    #ifdef __TABLE
+        auto * const c = __contention(ptr);
+        __atomic_thread_fence(__ATOMIC_SEQ_CST);
+        if (0 != __atomic_load_n(&c->waiters, __ATOMIC_RELAXED))
+    #endif
+            __do_direct_wake(ptr, true);
+    }
+    template <class _Tp, typename std::enable_if<__type_used_directly(_Tp), int>::type = 1>
+    void __cxx_atomic_notify_one(_Tp const* ptr) {
+    #ifdef __TABLE
+        auto * const c = __contention(ptr);
+        __atomic_thread_fence(__ATOMIC_SEQ_CST);
+        if (0 != __atomic_load_n(&c->waiters, __ATOMIC_RELAXED))
+    #endif
+            __do_direct_wake(ptr, false);
+    }
+
+#else // __FUTEX || __CONDVAR
+
+    template <class _Tp>
+    __ABI void __cxx_atomic_try_wait_slow(_Tp const* ptr, _Tp val, int order) {
+        __cxx_atomic_try_wait_slow_fallback(ptr, val, order);
+    }
+    template <class _Tp>
+    __ABI void __cxx_atomic_notify_one(_Tp const* ptr) { }
+    template <class _Tp>
+    __ABI void __cxx_atomic_notify_all(_Tp const* ptr) { }
+
+#endif // __FUTEX || __CONDVAR
+
+template <class _Tp>
+__ABI void __cxx_atomic_wait(_Tp const* ptr, _Tp const val, int order) {
+#ifndef __NO_SPIN
+    if(__builtin_expect(__atomic_load_n(ptr, order) != val,1))
+        return;
+    for(int i = 0; i < 16; ++i) {
+        if(__atomic_load_n(ptr, order) != val)
+            return;
+        if(i < 12)
+            __YIELD_PROCESSOR();
+        else
+            __YIELD();
+    }
+#endif
+    while(val == __atomic_load_n(ptr, order))
+#ifndef __NO_WAIT
+        __cxx_atomic_try_wait_slow(ptr, val, order)
+#endif
+        ;
+}
+
+#include <atomic>
+
+namespace parlay {
+
+    template <class _Tp, class _Tv>
+    __ABI void atomic_wait_explicit(std::atomic<_Tp> const* a, _Tv val, std::memory_order order) {
+        __cxx_atomic_wait((const _Tp*)a, (_Tp)val, (int)order);
+    }
+    template <class _Tp, class _Tv>
+    __ABI void atomic_wait(std::atomic<_Tp> const* a, _Tv val) {
+        parlay::atomic_wait_explicit(a, val, std::memory_order_seq_cst);
+    }
+    template <class _Tp>
+    __ABI void atomic_notify_one(std::atomic<_Tp> const* a) {
+        __cxx_atomic_notify_one((const _Tp*)a);
+    }
+    template <class _Tp>
+    __ABI void atomic_notify_all(std::atomic<_Tp> const* a) {
+        __cxx_atomic_notify_all((const _Tp*)a);
+    }
+
+}
+
+// modified from https://raw.githubusercontent.com/ogiroux/atomic_wait/master/lib/source.cpp
+
+#ifdef __TABLE
+
+extern inline contended_t * __contention(volatile void const * p) {
+    static contended_t contention[256];
+    return contention + ((uintptr_t)p & 255);
+}
+
+#endif //__TABLE
+
+#else // !__cpp_lib_atomic_wait
+
+#include <atomic>
+
+namespace parlay {
+
+    template <class _Tp, class _Tv>
+    const auto atomic_wait_explicit = std::atomic_wait_explicit<_Tp, _Tv>;
+
+    template <class _Tp, class _Tv>
+    const auto atomic_wait = std::atomic_wait<_Tp, _Tv>;
+
+    template <class _Tp>
+    const auto atomic_notify_one = std::atomic_notify_one<_Tp>;
+
+    template <class _Tp>
+    const auto atomic_notify_all = std::atomic_notify_all<_Tp>;
+
+}
+
+#endif // !__cpp_lib_atomic_wait
+
+#endif //__ATOMIC_WAIT_INCLUDED

--- a/include/parlay/internal/scheduler_plugins/sequential.h
+++ b/include/parlay/internal/scheduler_plugins/sequential.h
@@ -17,7 +17,7 @@ inline void set_num_workers(int) { }
 #endif
 
 template <class F>
-inline void parallel_for(size_t start, size_t end, F f, long, bool) {
+inline void parallel_for(size_t start, size_t end, F&& f, long, bool) {
   for (size_t i=start; i<end; i++) {
     f(i);
   }
@@ -28,8 +28,9 @@ inline void parallel_for(size_t start, size_t end, F f, long, bool) {
 #endif
 
 template <typename Lf, typename Rf>
-inline void par_do(Lf left, Rf right, bool) {
-  left(); right();
+inline void par_do(Lf&& left, Rf&& right, bool) {
+  std::forward<Lf>(left)();
+  std::forward<Rf>(right)();
 }
 
 }  // namespace parlay

--- a/include/parlay/internal/work_stealing_deque.h
+++ b/include/parlay/internal/work_stealing_deque.h
@@ -1,0 +1,121 @@
+
+#ifndef PARLAY_INTERNAL_WORK_STEALING_DEQUE_H_
+#define PARLAY_INTERNAL_WORK_STEALING_DEQUE_H_
+
+#include <cassert>
+
+#include <atomic>
+#include <iostream>
+#include <utility>
+
+namespace parlay {
+namespace internal {
+
+// Deque from Arora, Blumofe, and Plaxton (SPAA, 1998).
+//
+// Supports:
+//
+// push_bottom:   Only the owning thread may call this
+// pop_bottom:    Only the owning thread may call this
+// pop_top:       Non-owning threads may call this
+//
+template <typename Job>
+struct Deque {
+  using qidx = unsigned int;
+  using tag_t = unsigned int;
+
+  // use std::atomic<age_t> for atomic access.
+  // Note: Explicit alignment specifier required
+  // to ensure that Clang inlines atomic loads.
+  struct alignas(int64_t) age_t {
+    // cppcheck bug prevents it from seeing usage with braced initializer
+    tag_t tag;                // cppcheck-suppress unusedStructMember
+    qidx top;                 // cppcheck-suppress unusedStructMember
+  };
+
+  // align to avoid false sharing
+  struct alignas(64) padded_job {
+    std::atomic<Job*> job;
+  };
+
+  static constexpr int q_size = 1000;
+  std::atomic<qidx> bot;
+  std::atomic<age_t> age;
+  std::array<padded_job, q_size> deq;
+
+  Deque() : bot(0), age(age_t{0, 0}) {}
+
+  // Adds a new job to the bottom of the queue. Only the owning
+  // thread can push new items. This must not be called by any
+  // other thread.
+  //
+  // Returns true if the queue was empty before this push
+  bool push_bottom(Job* job) {
+    auto local_bot = bot.load(std::memory_order_relaxed);      // atomic load
+    deq[local_bot].job.store(job, std::memory_order_relaxed);  // shared store
+    local_bot += 1;
+    if (local_bot == q_size) {
+      std::cerr << "internal error: scheduler queue overflow" << std::endl;
+      std::abort();
+    }
+    bot.store(local_bot, std::memory_order_relaxed);  // shared store
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    return (local_bot == 1);
+  }
+
+  // Pop an item from the top of the queue, i.e., the end that is not
+  // pushed onto. Threads other than the owner can use this function.
+  //
+  // Returns {job, empty}, where empty is true if job was the
+  // only job on the queue, i.e., the queue is now empty
+  std::pair<Job*, bool> pop_top() {
+    auto old_age = age.load(std::memory_order_relaxed);    // atomic load
+    auto local_bot = bot.load(std::memory_order_relaxed);  // atomic load
+    if (local_bot > old_age.top) {
+      auto job = deq[old_age.top].job.load(std::memory_order_relaxed);  // atomic load
+      auto new_age = old_age;
+      new_age.top = new_age.top + 1;
+      if (age.compare_exchange_strong(old_age, new_age))
+        return {job, (local_bot == old_age.top + 1)};
+      else
+        return {nullptr, (local_bot == old_age.top + 1)};
+    }
+    return {nullptr, true};
+  }
+
+  // Pop an item from the bottom of the queue. Only the owning
+  // thread can pop from this end. This must not be called by any
+  // other thread.
+  Job* pop_bottom() {
+    Job* result = nullptr;
+    auto local_bot = bot.load(std::memory_order_relaxed);  // atomic load
+    if (local_bot != 0) {
+      local_bot--;
+      bot.store(local_bot, std::memory_order_relaxed);  // shared store
+      std::atomic_thread_fence(std::memory_order_seq_cst);
+      auto job =
+          deq[local_bot].job.load(std::memory_order_relaxed);  // atomic load
+      auto old_age = age.load(std::memory_order_relaxed);      // atomic load
+      if (local_bot > old_age.top)
+        result = job;
+      else {
+        bot.store(0, std::memory_order_relaxed);  // shared store
+        auto new_age = age_t{old_age.tag + 1, 0};
+        if ((local_bot == old_age.top) &&
+            age.compare_exchange_strong(old_age, new_age))
+          result = job;
+        else {
+          age.store(new_age, std::memory_order_relaxed);  // shared store
+          result = nullptr;
+        }
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+      }
+    }
+    return result;
+  }
+};
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_WORK_STEALING_DEQUE_H_

--- a/include/parlay/internal/work_stealing_job.h
+++ b/include/parlay/internal/work_stealing_job.h
@@ -5,6 +5,7 @@
 #include <cassert>
 
 #include <atomic>
+#include <thread>
 #include <type_traits>
 
 #include "atomic_wait.h"
@@ -23,13 +24,13 @@ struct WorkStealingJob {
     assert(done.load(std::memory_order_relaxed) == false);
     execute();
     done.store(true, std::memory_order_release);
-    parlay::atomic_notify_all(&done);
   }
   [[nodiscard]] bool finished() const noexcept {
     return done.load(std::memory_order_acquire);
   }
-  void wait_for() const noexcept {
-    parlay::atomic_wait(&done, false);
+  void wait() const noexcept {
+    while (!finished())
+      std::this_thread::yield();
   }
  protected:
   virtual void execute() = 0;

--- a/include/parlay/scheduler.h
+++ b/include/parlay/scheduler.h
@@ -141,7 +141,7 @@ struct scheduler {
   // flag is set to true.
   void worker(size_t id) {
     thread_id = id;  // thread-local write
-    wait_for_work();
+    //wait_for_work();
     while (!finished()) {
       Job* job = get_job([&]() { return finished(); });
       if (job) {

--- a/include/parlay/scheduler.h
+++ b/include/parlay/scheduler.h
@@ -52,6 +52,11 @@ template <typename Job>
 struct scheduler {
   static_assert(std::is_invocable_r_v<void, Job&>);
 
+  // After SLEEP_FACTOR * P unsuccessful steal attempts, a
+  // worker will go to sleep until it is notified that there
+  // is more work to steal, in order to save CPU time
+  constexpr size_t SLEEP_FACTOR = 1000;
+
  public:
   unsigned int num_threads;
 
@@ -172,7 +177,7 @@ struct scheduler {
   Job* steal_job(F&& break_early) {
     size_t id = worker_id();
     // By coupon collector's problem, this should touch all.
-    for (int i = 0; i <= num_deques * 100; i++) {
+    for (int i = 0; i <= SLEEP_FACTOR * num_deques; i++) {
       if (break_early()) return nullptr;
       Job* job = try_steal(id);
       if (job) return job;
@@ -221,6 +226,7 @@ struct scheduler {
     // they might therefore miss the flag to finish
     while (num_finished_workers.load() < num_threads - 1) {
       wake_up_all_workers();
+      std::this_thread::yield();
     }
     for (unsigned int i = 1; i < num_threads; i++) {
       spawned_threads[i - 1].join();

--- a/include/parlay/scheduler.h
+++ b/include/parlay/scheduler.h
@@ -17,7 +17,6 @@
 #include <utility>
 #include <vector>
 
-#include "internal/atomic_wait.h"
 #include "internal/work_stealing_deque.h"
 #include "internal/work_stealing_job.h"
 
@@ -46,6 +45,10 @@
 #define PARLAY_ELASTIC_STEAL_TIMEOUT 10000
 #endif
 
+
+#if PARLAY_ELASTIC_PARALLELISM
+#include "internal/atomic_wait.h"
+#endif
 
 namespace parlay {
 

--- a/include/parlay/scheduler.h
+++ b/include/parlay/scheduler.h
@@ -55,7 +55,7 @@ struct scheduler {
   // After SLEEP_FACTOR * P unsuccessful steal attempts, a
   // worker will go to sleep until it is notified that there
   // is more work to steal, in order to save CPU time
-  constexpr size_t SLEEP_FACTOR = 1000;
+  constexpr static size_t SLEEP_FACTOR = 1000;
 
  public:
   unsigned int num_threads;
@@ -177,7 +177,7 @@ struct scheduler {
   Job* steal_job(F&& break_early) {
     size_t id = worker_id();
     // By coupon collector's problem, this should touch all.
-    for (int i = 0; i <= SLEEP_FACTOR * num_deques; i++) {
+    for (size_t i = 0; i <= SLEEP_FACTOR * num_deques; i++) {
       if (break_early()) return nullptr;
       Job* job = try_steal(id);
       if (job) return job;

--- a/include/parlay/scheduler.h
+++ b/include/parlay/scheduler.h
@@ -59,8 +59,8 @@ struct scheduler {
   // After SLEEP_FACTOR rounds of unsuccessful steals, a worker
   // will go to sleep until it is notified that there is more
   // work to steal, in order to save CPU time
-  constexpr static size_t YIELD_FACTOR = 100;
-  constexpr static size_t SLEEP_FACTOR = 100;
+  constexpr static size_t YIELD_FACTOR = 200;
+  constexpr static size_t SLEEP_FACTOR = 1000;
 
  public:
   unsigned int num_threads;
@@ -188,7 +188,7 @@ struct scheduler {
         Job* job = try_steal(id);
         if (job) return job;
       }
-      std::this_thread::yield();
+      std::this_thread::sleep_for(std::chrono::nanoseconds(num_deques * 100));
     }
     return nullptr;
   }


### PR DESCRIPTION
This patch involves a substantial new feature for the work-stealing scheduler.  Now, if the scheduler fails to find enough work to saturate the workers, they will go to sleep and wait until there is more work available.  This means that while the code is running only sequential code, or is blocked on user input, the workers will not be consuming CPU time.

This feature is enabled by default, since experiments show it to have no substantial performance impact (bench_standard results are within 0.04% on average). It can be disabled by setting the compile definition `PARLAY_ELASTIC_PARALLELISM` to `false`.  The time that workers will attempt to steal before timing out and going to sleep can be controlled with the macro `PARLAY_ELASTIC_STEAL_TIMEOUT`, which is in microseconds (default is `10000`, i.e., 10ms, and seems to work well).

This addresses the feature request #33 and subsumes PR #34 which solved the same problem but resulted in a slowdown on the benchmarks. It also contains the minor bug fix for #51.

[benchmarks.zip](https://github.com/cmuparlay/parlaylib/files/11144526/benchmarks.zip)


