### PR TITLE
Fix memory orders for ARM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # -------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 3.14)
-project(PARLAY VERSION 2.1.7
+project(PARLAY VERSION 2.1.8
         DESCRIPTION "A collection of parallel algorithms and other support for parallelism in C++"
         LANGUAGES CXX)
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -7,7 +7,6 @@ set(NUMA_COMMAND numactl -i all)
 function(add_benchmark NAME)
   add_executable(bench_${NAME} bench_${NAME}.cpp)
   target_link_libraries(bench_${NAME} PRIVATE parlay benchmark_main)
-  target_compile_options(bench_${NAME} PRIVATE -march=native)
   target_compile_definitions(bench_${NAME} PRIVATE -DPARLAY_BENCHMARK_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}")
   if(PARLAY_BENCHMARK_NUMACTL_TARGETS)
     add_custom_target(numactl_bench_${NAME}

--- a/include/parlay/internal/work_stealing_deque.h
+++ b/include/parlay/internal/work_stealing_deque.h
@@ -58,7 +58,8 @@ struct Deque {
       std::cerr << "internal error: scheduler queue overflow" << std::endl;
       std::abort();
     }
-    bot.store(local_bot, std::memory_order_seq_cst);  // shared store
+    bot.store(local_bot, std::memory_order_release);  // shared store
+    std::atomic_thread_fence(std::memory_order_seq_cst);
     return (local_bot == 1);
   }
 
@@ -104,9 +105,10 @@ struct Deque {
             age.compare_exchange_strong(old_age, new_age))
           result = job;
         else {
-          age.store(new_age, std::memory_order_seq_cst);  // shared store
+          age.store(new_age, std::memory_order_release);  // shared store
           result = nullptr;
         }
+        std::atomic_thread_fence(std::memory_order_seq_cst);
       }
     }
     return result;

--- a/include/parlay/internal/work_stealing_deque.h
+++ b/include/parlay/internal/work_stealing_deque.h
@@ -58,8 +58,7 @@ struct Deque {
       std::cerr << "internal error: scheduler queue overflow" << std::endl;
       std::abort();
     }
-    bot.store(local_bot, std::memory_order_release);  // shared store
-    std::atomic_thread_fence(std::memory_order_seq_cst);
+    bot.store(local_bot, std::memory_order_seq_cst);  // shared store
     return (local_bot == 1);
   }
 
@@ -105,10 +104,9 @@ struct Deque {
             age.compare_exchange_strong(old_age, new_age))
           result = job;
         else {
-          age.store(new_age, std::memory_order_release);  // shared store
+          age.store(new_age, std::memory_order_seq_cst);  // shared store
           result = nullptr;
         }
-        std::atomic_thread_fence(std::memory_order_seq_cst);
       }
     }
     return result;


### PR DESCRIPTION
The scheduler is currently too relaxed and crashes on ARM processors.  This corrects the issue with no performance penalty on the benchmark set.

[fix-memory-order.zip](https://github.com/cmuparlay/parlaylib/files/11302382/fix-memory-order.zip)
