### PR TITLE
small cleanups from clang's -Weverything

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # -------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 3.14)
-project(PARLAY VERSION 2.2.2
+project(PARLAY VERSION 2.2.3
         DESCRIPTION "A collection of parallel algorithms and other support for parallelism in C++"
         LANGUAGES CXX)
 

--- a/examples/delaunay.h
+++ b/examples/delaunay.h
@@ -39,7 +39,7 @@ struct triangle {
 // Since we often check multiple points against a single circle
 // this reduces the work.
 // Projects onto a parobola and does a planeside test.
-auto in_circle (point a, point b, point d) {
+inline auto in_circle (point a, point b, point d) {
   struct vect { double x,y,z;};
   auto project = [=] (point p) {
     double px = p.x-d.x; double py = p.y-d.y;

--- a/include/parlay/alloc.h
+++ b/include/parlay/alloc.h
@@ -179,7 +179,7 @@ struct allocator {
     }
   }
 
-  constexpr allocator() { internal::get_default_allocator(); };
+  constexpr allocator() { internal::get_default_allocator(); }
   template <class U> /* implicit */ constexpr allocator(const allocator<U>&) noexcept { }
 };
 
@@ -271,8 +271,8 @@ public:
   template <typename ... Args>
   static T* allocate(Args... args) { return create(std::forward<Args>(args)...); }
   static void retire(T* ptr) { destroy(ptr); }
-  static void init(size_t, size_t) {};
-  static void init() {};
+  static void init(size_t, size_t) {}
+  static void init() {}
   static void reserve([[maybe_unused]] size_t n = default_alloc_size) { }
   static void finish() { get_allocator().clear(); }
   static size_t block_size () { return get_allocator().get_block_size(); }

--- a/include/parlay/hash_table.h
+++ b/include/parlay/hash_table.h
@@ -69,7 +69,7 @@ class hashtable {
       TA(sequence<eType>(m, empty)) {
   }
 
-  ~hashtable() { };
+  ~hashtable() { }
 
   // prioritized linear probing
   //   a new key will bump an existing key up if it has a higher priority

--- a/include/parlay/internal/atomic_wait.h
+++ b/include/parlay/internal/atomic_wait.h
@@ -398,23 +398,23 @@ extern inline contended_t * __contention(volatile void const * p) {
 
 namespace parlay {
 
-    template <class _Tp>
-    void atomic_wait_explicit(const std::atomic<_Tp>* a, parlay::type_identity_t<_Tp> val, std::memory_order order) {
+    template <class Tp_>
+    void atomic_wait_explicit(const std::atomic<Tp_>* a, parlay::type_identity_t<Tp_> val, std::memory_order order) {
         std::atomic_wait_explicit(a, val, order);
     }
 
-    template <class _Tp>
-    void atomic_wait(const std::atomic<_Tp>* a, parlay::type_identity_t<_Tp> val) {
+    template <class Tp_>
+    void atomic_wait(const std::atomic<Tp_>* a, parlay::type_identity_t<Tp_> val) {
         std::atomic_wait(a, val);
     }
 
-    template <class _Tp>
-    void atomic_notify_one(std::atomic<_Tp>* a) {
+    template <class Tp_>
+    void atomic_notify_one(std::atomic<Tp_>* a) {
         std::atomic_notify_one(a);
     }
 
-    template <class _Tp>
-    void atomic_notify_all(std::atomic<_Tp>* a) {
+    template <class Tp_>
+    void atomic_notify_all(std::atomic<Tp_>* a) {
         std::atomic_notify_all(a);
     }
 

--- a/include/parlay/internal/block_allocator.h
+++ b/include/parlay/internal/block_allocator.h
@@ -50,7 +50,7 @@ struct block_allocator {
     size_t sz;
     block* head;
     block* mid;
-    local_list() : sz(0), head(nullptr), mid(nullptr) {};
+    local_list() : sz(0), head(nullptr), mid(nullptr) {}
   };
 
   hazptr_stack<std::byte*> allocated_buffers;

--- a/include/parlay/internal/delayed/flatten.h
+++ b/include/parlay/internal/delayed/flatten.h
@@ -91,7 +91,7 @@ struct block_delayed_flatten_t :
    public:
     using iterator_category = std::forward_iterator_tag;
     using reference = range_reference_type_t<range_reference_type_t<base_view_type>>;
-    using value_type = range_value_type_t<range_reference_type_t<base_view_type>>;;
+    using value_type = range_value_type_t<range_reference_type_t<base_view_type>>;
     using difference_type = std::ptrdiff_t;
     using pointer = void;
 

--- a/include/parlay/internal/group_by.h
+++ b/include/parlay/internal/group_by.h
@@ -96,7 +96,7 @@ struct reduce_by_key_helper {
   using result_type = std::pair<key_type, value_type>;
   Monoid monoid; Hash hash; Equal equal;
   reduce_by_key_helper(Monoid const &m, Hash const &h, Equal const &e) :
-      monoid(m), hash(h), equal(e) {};
+      monoid(m), hash(h), equal(e) {}
 
   template<typename T> static const key_type& get_key(const T& p) { return std::get<0>(p);}
   template<typename T> static key_type& get_key(T& p) { return std::get<0>(p);}
@@ -136,7 +136,7 @@ struct group_by_key_helper {
   using seq_type = sequence<val_type>;
   using result_type = std::pair<key_type,seq_type>;
   Hash hash; Equal equal;
-  group_by_key_helper(Hash const &h, Equal const &e) : hash(h), equal(e) {};
+  group_by_key_helper(Hash const &h, Equal const &e) : hash(h), equal(e) {}
   static const key_type& get_key(in_type const &p) { return std::get<0>(p);}
   static key_type& get_key(in_type &p) { return std::get<0>(p);}
   static key_type& get_key(result_type &p) {return std::get<0>(p);}
@@ -169,7 +169,7 @@ struct count_by_key_helper {
   using val_type = sum_type;
   using result_type = std::pair<key_type,val_type>;
   Hash hash; Equal equal;
-  count_by_key_helper(Hash const &h, Equal const &e) : hash(h), equal(e) {};
+  count_by_key_helper(Hash const &h, Equal const &e) : hash(h), equal(e) {}
   static const key_type& get_key(in_type const &k) {return k;}
   static key_type& get_key(in_type &k) {return k;}
   static key_type& get_key(result_type &p) {return std::get<0>(p);}
@@ -199,14 +199,14 @@ struct remove_duplicates_helper {
   using key_type = in_type;
   using result_type = in_type;
   Hash hash; Equal equal;
-  remove_duplicates_helper(Hash const &h, Equal const &e) : hash(h), equal(e) {};
+  remove_duplicates_helper(Hash const &h, Equal const &e) : hash(h), equal(e) {}
   static const key_type& get_key(in_type const &k) { return k;}
   static key_type& get_key(in_type &k) { return k;}
   static void init(result_type &, in_type const&) {}
   static void update(result_type &, in_type const&) {}
   static void destruct_val(in_type &) {}
   template <typename Range>
-  static result_type reduce(Range S) {return S[0];};
+  static result_type reduce(Range S) {return S[0];}
 };
 
 // should be made more efficient by avoiding generating and then stripping counts
@@ -234,10 +234,10 @@ auto reduce_by_index(R&& A, size_t num_buckets, Monoid&& monoid = {}) {
     using key_type = std::tuple_element_t<0, in_type>;
     using val_type = std::tuple_element_t<1, in_type>;
     Monoid mon;
-    static key_type get_key(const in_type& a) { return std::get<0>(a); };
-    static val_type get_val(const in_type& a) { return std::get<1>(a); };
+    static key_type get_key(const in_type& a) { return std::get<0>(a); }
+    static val_type get_val(const in_type& a) { return std::get<1>(a); }
     val_type init() const {return mon.identity;}
-    void update(val_type& d, val_type const &a) const { d = mon(d, a); };
+    void update(val_type& d, val_type const &a) const { d = mon(d, a); }
     void combine(val_type& d, slice<in_type*,in_type*> s) const {
       auto vals = internal::delayed_map(s, [&] (in_type &v) { return std::get<1>(v); });
       d = internal::reduce(vals, mon);

--- a/include/parlay/internal/posix/file_map_impl_posix.h
+++ b/include/parlay/internal/posix/file_map_impl_posix.h
@@ -47,7 +47,7 @@ class file_map {
       assert(fstat_res != -1);
       assert(S_ISREG(sb.st_mode));
     
-      char *p = static_cast<char*>(mmap(0, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0));
+      char *p = static_cast<char*>(mmap(nullptr, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0));
       assert(p != MAP_FAILED);
       [[maybe_unused]] int close_p = ::close(fd);
       assert(close_p != -1);

--- a/include/parlay/internal/sequence_base.h
+++ b/include/parlay/internal/sequence_base.h
@@ -398,7 +398,7 @@ struct alignas(uint64_t) sequence_base {
     // sequence.
     struct _data_impl {
       _data_impl() {}
-      ~_data_impl(){};
+      ~_data_impl(){}
 
       union {
         typename std::conditional<use_sso, short_seq, void*>::type short_mode;

--- a/include/parlay/internal/sequence_base.h
+++ b/include/parlay/internal/sequence_base.h
@@ -357,7 +357,6 @@ struct alignas(uint64_t) sequence_base {
       uint64_t n : 48;
 
       long_seq(capacitated_buffer _buffer, uint64_t _n) : buffer(_buffer), n(_n) {}
-      ~long_seq() = default;
 
       void set_size(size_t new_size) { n = new_size; }
 

--- a/include/parlay/io.h
+++ b/include/parlay/io.h
@@ -291,7 +291,7 @@ inline chars to_chars(long v) {
 
 inline chars to_chars(int v) {
   return to_chars((long) v);
-};
+}
 
 inline chars to_chars(unsigned long v) {
   constexpr int max_len = 21;
@@ -302,7 +302,7 @@ inline chars to_chars(unsigned long v) {
 
 inline chars to_chars(unsigned int v) {
   return to_chars((unsigned long) v);
-};
+}
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -336,7 +336,7 @@ inline chars to_chars(double v) {
 
 inline chars to_chars(float v) {
   return to_chars((double) v);
-};
+}
 
 inline chars to_chars(const std::string& s) {
   return chars::from_function(s.size(), [&](size_t i) -> char { return s[i]; });

--- a/include/parlay/primitives.h
+++ b/include/parlay/primitives.h
@@ -772,7 +772,7 @@ inline bool operator<(const sequence<T,Alloc,EnableSSO> &a, const sequence<T,All
   auto ea = sa + (std::min)(a.size(),b.size());
   while (sa < ea && *sa == *sb) {sa++; sb++;}
   return sa == ea ? (a.size() < b.size()) : *sa < *sb;
-};
+}
 
 
 /* -------------------- Remove duplicates -------------------- */

--- a/include/parlay/primitives.h
+++ b/include/parlay/primitives.h
@@ -1279,7 +1279,7 @@ auto kth_smallest_copy(Range&& in, size_t k, Compare&& less = {}) {
   auto [offsets, total] = parlay::scan(sums);
   assert(total == n);
 
-  auto id = std::upper_bound(offsets.begin(), offsets.end(), k) - offsets.begin() - 1;
+  auto id = static_cast<size_t>(std::upper_bound(offsets.begin(), offsets.end(), k) - offsets.begin() - 1);
   auto bucket_length = ((id == offsets.size() - 1) ? total : offsets[id+1]) - offsets[id];
 
   // Grab the contents of the bucket containing the k'th element.  Exclude the pivot

--- a/include/parlay/random.h
+++ b/include/parlay/random.h
@@ -62,8 +62,8 @@ struct random_generator {
 
 struct random {
  public:
-  random(size_t seed) : state(seed){};
-  random() : state(0){};
+  random(size_t seed) : state(seed){}
+  random() : state(0){}
   random fork(uint64_t i) const { return random(static_cast<size_t>(hash64(hash64(i + state)))); }
   random next() const { return fork(0); }
   size_t ith_rand(uint64_t i) const { return static_cast<size_t>(hash64(i + state)); }

--- a/include/parlay/slice.h
+++ b/include/parlay/slice.h
@@ -67,7 +67,7 @@ struct slice {
   using iterator = It;
   using sentinel = S;
   
-  slice(iterator s, sentinel e) : s(s), e(e){};
+  slice(iterator s, sentinel e) : s(s), e(e){}
   
   // Copy construction and assignment
   slice(const slice<It,S>&) = default;

--- a/include/parlay/thread_specific.h
+++ b/include/parlay/thread_specific.h
@@ -107,7 +107,7 @@ struct Uninitialized {
     T value;
   };
 
-  Uninitialized() noexcept { };
+  Uninitialized() noexcept { }
 
   T& operator*() { return value; }
 

--- a/include/parlay/utilities.h
+++ b/include/parlay/utilities.h
@@ -469,7 +469,7 @@ struct padded;
 // Use user-defined conversions to pad primitive types
 template<typename T, size_t Size>
 struct alignas(Size) padded<T, Size, typename std::enable_if_t<std::is_scalar_v<T>>> {
-  padded() : x{} {};
+  padded() : x{} {}
   /* implicit */ padded(T _x) : x(_x) { }       // cppcheck-suppress noExplicitConstructor    // NOLINT
   /* implicit */ operator T&() & { return x; }                                                // NOLINT
   /* implicit */ operator const T&() const& { return x; }                                     // NOLINT

--- a/test/test_sorting_primitives.cpp
+++ b/test/test_sorting_primitives.cpp
@@ -298,7 +298,7 @@ TEST(TestSortingPrimitives, TestStableIntegerSortInplaceNonContiguous) {
 }
 
 TEST(TestSortingPrimitives, TestCountingSort) {
-  const size_t num_buckets = size_t{1} << 16;
+  size_t num_buckets = 1ULL << 16;
   auto s = parlay::tabulate(100000, [num_buckets](unsigned long long i) -> unsigned long long {
     return (50021 * i + 61) % num_buckets;
   });
@@ -311,7 +311,7 @@ TEST(TestSortingPrimitives, TestCountingSort) {
 }
 
 TEST(TestSortingPrimitives, TestCountingSortUnstable) {
-  const size_t num_buckets = size_t{1} << 16;
+  size_t num_buckets = 1ULL << 16;
   auto s = parlay::tabulate(100000, [num_buckets](long long i) -> UnstablePair {
     UnstablePair x;
     x.x = (53 * i + 61) % num_buckets;


### PR DESCRIPTION
These are small cleanups that are found by clangs -Weverything.  Cleaning them here means that other projects that include parlaylib in them can also compile with these extra warnings without having to selectively disable them. 

In addition to the warnings I fixed, here is a set of additional warnings.  I did not fix these before asking since they can get a little more opinionated, they are mostly around variable shadowing, changing signedness, and changing precision.

[warnings.txt](https://github.com/cmuparlay/parlaylib/files/12697169/warnings.txt)
