### PR TITLE
Rewrite relocation to be compliant with P1144

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # -------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 3.14)
-project(PARLAY VERSION 2.2.1
+project(PARLAY VERSION 2.3.1
         DESCRIPTION "A collection of parallel algorithms and other support for parallelism in C++"
         LANGUAGES CXX)
 

--- a/benchmark/bench_sequence.cpp
+++ b/benchmark/bench_sequence.cpp
@@ -57,7 +57,7 @@ struct NotRelocatable {
   std::unique_ptr<int> x;
   NotRelocatable() = default;
   NotRelocatable(int x_) : x(std::make_unique<int>(x_)) { }
-  NotRelocatable(NotRelocatable&& other) : x(std::move(other.x)) { }
+  NotRelocatable(NotRelocatable&& other) noexcept : x(std::move(other.x)) { }
   ~NotRelocatable() { }
 };
 static_assert(!parlay::is_trivially_relocatable_v<NotRelocatable>);

--- a/benchmark/bench_sequence.cpp
+++ b/benchmark/bench_sequence.cpp
@@ -27,6 +27,61 @@ static void bench_short_subscript(benchmark::State& state) {
   }
 }
 
+static void bench_grow_int64(benchmark::State& state) {
+  parlay::sequence<int64_t> s;
+  for (auto _ : state) {
+    state.PauseTiming();
+    s = parlay::sequence<int64_t>(10000000);
+    state.ResumeTiming();
+    s.reserve(s.capacity() + 1);    // Trigger grow
+  }
+}
+
+// No annotation needed since this one should be detectable
+struct Relocatable {
+  std::unique_ptr<int> x;
+  Relocatable() = default;
+  Relocatable(int x_) : x(std::make_unique<int>(x_)) { }
+};
+
+#if defined(PARLAY_MUST_SPECIALIZE_IS_TRIVIALLY_RELOCATABLE)
+namespace parlay {
+template<>
+PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(Relocatable);
+}
+#endif
+
+static_assert(parlay::is_trivially_relocatable_v<Relocatable>);
+
+struct NotRelocatable {
+  std::unique_ptr<int> x;
+  NotRelocatable() = default;
+  NotRelocatable(int x_) : x(std::make_unique<int>(x_)) { }
+  NotRelocatable(NotRelocatable&& other) : x(std::move(other.x)) { }
+  ~NotRelocatable() { }
+};
+static_assert(!parlay::is_trivially_relocatable_v<NotRelocatable>);
+
+static void bench_grow_relocatable(benchmark::State& state) {
+  parlay::sequence<Relocatable> s;
+  for (auto _ : state) {
+    state.PauseTiming();
+    s = parlay::sequence<Relocatable>(10000000);
+    state.ResumeTiming();
+    s.reserve(s.capacity() + 1);    // Trigger grow
+  }
+}
+
+static void bench_grow_nonrelocatable(benchmark::State& state) {
+  parlay::sequence<NotRelocatable> s;
+  for (auto _ : state) {
+    state.PauseTiming();
+    s = parlay::sequence<NotRelocatable>(10000000);
+    state.ResumeTiming();
+    s.reserve(s.capacity() + 1);    // Trigger grow
+  }
+}
+
 // ------------------------- Registration -------------------------------
 
 #define BENCH(NAME) BENCHMARK(bench_ ## NAME)               \
@@ -35,3 +90,6 @@ static void bench_short_subscript(benchmark::State& state) {
 
 BENCH(subscript);
 BENCH(short_subscript);
+BENCH(grow_int64);
+BENCH(grow_relocatable);
+BENCH(grow_nonrelocatable);

--- a/include/parlay/alloc.h
+++ b/include/parlay/alloc.h
@@ -154,7 +154,7 @@ inline void p_free(void* ptr) {
 //    std::vector<int, parlay::allocator<int>>
 //
 template <typename T>
-struct allocator {
+struct PARLAY_TRIVIALLY_RELOCATABLE allocator {
   using value_type = T;
   T* allocate(size_t n) {
     // Use headerless blocks straight from the pool if the alignment is suitable,
@@ -183,8 +183,13 @@ struct allocator {
   template <class U> /* implicit */ constexpr allocator(const allocator<U>&) noexcept { }
 };
 
+#if defined(PARLAY_MUST_SPECIALIZE_IS_TRIVIALLY_RELOCATABLE)
+
 template<typename T>
-struct is_trivially_relocatable<allocator<T>> : std::true_type {};
+PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(allocator<T>);
+
+#endif
+
 
 template <class T, class U>
 bool operator==(const allocator<T>&, const allocator<U>&) { return true; }

--- a/include/parlay/alloc.h
+++ b/include/parlay/alloc.h
@@ -154,7 +154,7 @@ inline void p_free(void* ptr) {
 //    std::vector<int, parlay::allocator<int>>
 //
 template <typename T>
-struct PARLAY_TRIVIALLY_RELOCATABLE allocator {
+struct allocator {
   using value_type = T;
   T* allocate(size_t n) {
     // Use headerless blocks straight from the pool if the alignment is suitable,
@@ -183,12 +183,10 @@ struct PARLAY_TRIVIALLY_RELOCATABLE allocator {
   template <class U> /* implicit */ constexpr allocator(const allocator<U>&) noexcept { }
 };
 
-#if defined(PARLAY_MUST_SPECIALIZE_IS_TRIVIALLY_RELOCATABLE)
-
-template<typename T>
-PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(allocator<T>);
-
-#endif
+// Allocator should be trivially copyable since it is stateless and has no user-provided copy
+// constructor.  This should guarantee that it is also trivially relocatable.
+static_assert(std::is_trivially_copyable_v<allocator<int>>);
+static_assert(is_trivially_relocatable_v<allocator<int>>);
 
 
 template <class T, class U>

--- a/include/parlay/internal/bucket_sort.h
+++ b/include/parlay/internal/bucket_sort.h
@@ -42,7 +42,7 @@ void radix_step_(slice<InIterator, InIterator> A,
 
   for (size_t j = n; j > 0; j--) {
     auto x = --counts[keys[j-1]];
-    uninitialized_relocate(&B[x], &A[j-1]);
+    relocate_at(&A[j - 1], &B[x]);
   }
 }
 

--- a/include/parlay/internal/bucket_sort.h
+++ b/include/parlay/internal/bucket_sort.h
@@ -128,7 +128,7 @@ void base_sort(slice<InIterator, InIterator> in,
   else {
     quicksort(in.begin(), in.size(), f);
     if (!inplace) {
-      uninitialized_relocate_n(out.begin(), in.begin(), in.size());
+      parlay::uninitialized_relocate(in.begin(), in.end(), out.begin());
     }
   }
 }

--- a/include/parlay/internal/collect_reduce.h
+++ b/include/parlay/internal/collect_reduce.h
@@ -271,7 +271,7 @@ auto seq_collect_reduce_sparse(Slice A, Helper const &helper) {
   auto r = r_s.begin();
   size_t j = 0;
   for (size_t i = 0; i < table_size; i++)
-    if (flags[i]) uninitialized_relocate(&r[j++], &table[i]);
+    if (flags[i]) relocate_at(&table[i], &r[j++]);
   assert(j == count);
   return r_s;
 }

--- a/include/parlay/internal/counting_sort.h
+++ b/include/parlay/internal/counting_sort.h
@@ -320,7 +320,7 @@ auto count_sort_inplace(slice<InIterator, InIterator> In, KeyS const& Keys, size
   using value_type = typename slice<InIterator, InIterator>::value_type;
   auto Tmp = uninitialized_sequence<value_type>(In.size());
   auto a = count_sort<uninitialized_relocate_tag>(In, make_slice(Tmp), make_slice(Keys), num_buckets);
-  uninitialized_relocate_n(In.begin(), Tmp.begin(), In.size());
+  parlay::uninitialized_relocate(Tmp.begin(), Tmp.end(), In.begin());
   return a.first;
 }
 

--- a/include/parlay/internal/delayed/filter.h
+++ b/include/parlay/internal/delayed/filter.h
@@ -96,7 +96,7 @@ struct block_delayed_filter_t :
       }
     }
     auto res = sequence<It>::uninitialized(n);
-    uninitialized_relocate_n(res.begin(), temp.begin(), n);
+    parlay::uninitialized_relocate_n(temp.begin(), n, res.begin());
     return res;
   }
 

--- a/include/parlay/internal/delayed/filter_op.h
+++ b/include/parlay/internal/delayed/filter_op.h
@@ -85,7 +85,7 @@ struct block_delayed_filter_op_t :
       }
     }
     auto res = sequence<result_type>::uninitialized(n);
-    uninitialized_relocate_n(res.begin(), temp.begin(), n);
+    parlay::uninitialized_relocate_n(temp.begin(), n, res.begin());
     return res;
   }
 

--- a/include/parlay/internal/integer_sort.h
+++ b/include/parlay/internal/integer_sort.h
@@ -80,10 +80,10 @@ void seq_radix_sort_(slice<InIterator, InIterator> In,
   }
   
   if (swapped && inplace) {
-    uninitialized_relocate_n(In.begin(), Out.begin(), In.size());
+    parlay::uninitialized_relocate(Out.begin(), Out.end(), In.begin());
   }
   else if (!swapped && !inplace) {
-    uninitialized_relocate_n(Out.begin(), In.begin(), Out.size());
+    parlay::uninitialized_relocate(In.begin(), In.end(), Out.begin());
   }
 }
 
@@ -105,10 +105,10 @@ void seq_radix_sort(slice<InIterator, InIterator> In,
     size_t n = In.size();
     if (odd) {
       // We could just use assign_dispatch(Tmp[i], In[i]) for each i, but we
-      // can optimize better by calling destructive_move_slice, since this
+      // can optimize better by calling uninitialized_relocate, since this
       // has the ability to memcpy multiple elements at once
       if constexpr (std::is_same_v<assignment_tag, uninitialized_relocate_tag>) {
-        uninitialized_relocate_n(Tmp.begin(), In.begin(), Tmp.size());
+        parlay::uninitialized_relocate(In.begin(), In.end(), Tmp.begin());
       }
       else {
         for (size_t i = 0; i < n; i++)
@@ -117,7 +117,7 @@ void seq_radix_sort(slice<InIterator, InIterator> In,
       seq_radix_sort_(Tmp, Out, g, key_bits, false);
     } else {
       if constexpr (std::is_same_v<assignment_tag, uninitialized_relocate_tag>) {
-        uninitialized_relocate_n(Out.begin(), In.begin(), Out.size());
+        parlay::uninitialized_relocate(In.begin(), In.end(), Out.begin());
       }
       else {
         for (size_t i = 0; i < n; i++)
@@ -219,7 +219,7 @@ sequence<size_t> integer_sort_r(slice<InIterator, InIterator> In,
       // uninitialized_relocate_n, which can memcpy multiple elements at a time
       // to save on performing every copy individually.
       if constexpr (std::is_same_v<assignment_tag, uninitialized_relocate_tag>) {
-        uninitialized_relocate_n(Out.begin(), In.begin(), Out.size());
+        parlay::uninitialized_relocate(In.begin(), In.end(), Out.begin());
       }
       else {
         parallel_for(0, In.size(), [&](size_t i) {
@@ -248,7 +248,7 @@ sequence<size_t> integer_sort_r(slice<InIterator, InIterator> In,
   
     if constexpr (inplace_tag::value == true) {
       if (!one_bucket) {
-        uninitialized_relocate_n(In.begin(), Out.begin(), In.size());
+        parlay::uninitialized_relocate(Out.begin(), Out.end(), In.begin());
       }
     }
     

--- a/include/parlay/internal/merge_sort.h
+++ b/include/parlay/internal/merge_sort.h
@@ -28,7 +28,7 @@ void merge_sort_(slice<InIterator, InIterator> In,
     insertion_sort(In.begin(), In.size(), f);
     if (!inplace) {
       for (size_t i = 0; i < In.size(); i++) {
-        uninitialized_relocate(&Out[i], &In[i]);
+        relocate_at(&In[i], &Out[i]);
       }
     }
   }

--- a/include/parlay/internal/sample_sort.h
+++ b/include/parlay/internal/sample_sort.h
@@ -178,7 +178,7 @@ void sample_sort_inplace_(slice<InIterator, InIterator> In,
 
     // Sample block is already sorted, so we don't need to sort it again.
     // We can just move it straight over into the other sorted blocks
-    uninitialized_relocate_n(Tmp.begin(), sample_set.begin(), sample_set_size);
+    parlay::uninitialized_relocate(sample_set.begin(), sample_set.end(), Tmp.begin());
 
     // move data from blocks to buckets
     auto bucket_offsets =

--- a/include/parlay/internal/thread_id_pool.h
+++ b/include/parlay/internal/thread_id_pool.h
@@ -47,7 +47,7 @@ class ThreadIdPool : public std::enable_shared_from_this<ThreadIdPool> {
 
 
   ~ThreadIdPool() noexcept {
-    size_t num_destroyed = 0;
+    [[maybe_unused]] size_t num_destroyed = 0;
     for (auto current = available_ids.load(std::memory_order_relaxed); current; num_destroyed++) {
       auto old = std::exchange(current, current->next);
       delete old;

--- a/include/parlay/internal/uninitialized_iterator.h
+++ b/include/parlay/internal/uninitialized_iterator.h
@@ -1,0 +1,158 @@
+
+#ifndef PARLAY_INTERNAL_UNINITIALIZED_ITERATOR_H_
+#define PARLAY_INTERNAL_UNINITIALIZED_ITERATOR_H_
+
+#include <iterator>
+#include <type_traits>
+
+#include "../range.h"
+#include "../type_traits.h"
+
+namespace parlay {
+namespace internal {
+
+// Given a container of uninitialized<T>, you can wrap its iterators with
+// uninitialized_iterator_adapter to get an iterator whose value type is T!
+//
+// The resulting iterator will have the same iterator category as Iterator.
+template<typename Iterator>
+class uninitialized_iterator_adapter {
+ public:
+  using iterator_category = parlay::iterator_category_t<Iterator>;
+  using difference_type = parlay::iterator_difference_type_t<Iterator>;
+  using value_type = decltype(std::declval<parlay::iterator_value_type_t<Iterator>>().value);
+  using reference = std::add_lvalue_reference_t<value_type>;
+  using pointer = std::add_pointer_t<value_type>;
+
+  uninitialized_iterator_adapter(Iterator it_) : it(it_) {}
+
+  reference operator*() const { return it->value; }
+
+  pointer operator->() { return std::addressof(it->value); }
+
+  uninitialized_iterator_adapter& operator++() {
+    ++it;
+    return *this;
+  }
+
+  friend void swap(uninitialized_iterator_adapter& left, uninitialized_iterator_adapter& right) noexcept {
+    std::swap(left.it, right.it);
+  }
+
+  // ------------------------ Enabled if input iterator ------------------------
+
+  template<typename It = Iterator>
+  auto operator++(int) -> std::enable_if_t<parlay::is_input_iterator_v<It>, uninitialized_iterator_adapter> {
+    auto tmp = *this;
+    ++(*this);
+    return tmp;
+  }
+
+  template<typename It = Iterator>
+  auto operator==(const uninitialized_iterator_adapter& other) const
+      -> std::enable_if_t<parlay::is_input_iterator_v<It>, bool> {
+    return it == other.it;
+  }
+
+  template<typename It = Iterator>
+  auto operator!=(const uninitialized_iterator_adapter& other) const
+      -> std::enable_if_t<parlay::is_input_iterator_v<It>, bool> {
+    return it != other.it;
+  }
+
+  // ------------------------ Enabled if forward iterator ------------------------
+
+  // Can't SFINAE special member functions so this is close enough until C++20
+  template<typename It = Iterator, std::enable_if_t<parlay::is_forward_iterator_v<It>, int> = 0>
+  uninitialized_iterator_adapter() : it{} {}
+
+  // ------------------------ Enabled if bidirectional iterator ------------------------
+
+  template<typename It = Iterator>
+  auto operator--() -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adapter&> {
+    it--;
+    return *this;
+  }
+
+  template<typename It = Iterator>
+  auto operator--(int) -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adapter> {
+    auto tmp = *this;
+    --(*this);
+    return tmp;
+  }
+
+  // ------------------------ Enabled if random-access iterator ------------------------
+
+  template<typename It = Iterator>
+  auto operator+=(difference_type diff)
+      -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adapter&> {
+    it += diff;
+    return *this;
+  }
+
+  template<typename It = Iterator>
+  auto operator+(difference_type diff) const
+      -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adapter> {
+    auto result = *this;
+    result += diff;
+    return result;
+  }
+
+  template<typename It = Iterator>
+  auto operator-=(difference_type diff)
+      -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adapter&> {
+    it -= diff;
+    return *this;
+  }
+
+  template<typename It = Iterator>
+  auto operator-(difference_type diff) const
+      -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adapter> {
+    auto result = *this;
+    result -= diff;
+    return result;
+  }
+
+  template<typename It = Iterator>
+  auto operator-(const uninitialized_iterator_adapter& other) const
+      -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, difference_type> {
+    return it - other.it;
+  }
+
+  template<typename It = Iterator>
+  auto operator[](std::size_t p) const -> std::enable_if_t<parlay::is_random_access_iterator_v<It>, reference> {
+    return it[p].value;
+  }
+
+  template<typename It = Iterator>
+  auto operator<(const uninitialized_iterator_adapter& other) const
+      -> std::enable_if_t<parlay::is_random_access_iterator_v<It>, bool> {
+    return it < other.it;
+  }
+
+  template<typename It = Iterator>
+  auto operator<=(const uninitialized_iterator_adapter& other) const
+      -> std::enable_if_t<parlay::is_random_access_iterator_v<It>, bool> {
+    return it <= other.it;
+  }
+
+  template<typename It = Iterator>
+  auto operator>(const uninitialized_iterator_adapter& other) const
+      -> std::enable_if_t<parlay::is_random_access_iterator_v<It>, bool> {
+    return it > other.it;
+  }
+
+  template<typename It = Iterator>
+  auto operator>=(const uninitialized_iterator_adapter& other) const
+      -> std::enable_if_t<parlay::is_random_access_iterator_v<It>, bool> {
+    return it >= other.it;
+  }
+
+ private:
+  Iterator it;
+};
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_UNINITIALIZED_ITERATOR_H_

--- a/include/parlay/internal/uninitialized_iterator.h
+++ b/include/parlay/internal/uninitialized_iterator.h
@@ -12,11 +12,11 @@ namespace parlay {
 namespace internal {
 
 // Given a container of uninitialized<T>, you can wrap its iterators with
-// uninitialized_iterator_adapter to get an iterator whose value type is T!
+// uninitialized_iterator_adaptor to get an iterator whose value type is T!
 //
 // The resulting iterator will have the same iterator category as Iterator.
 template<typename Iterator>
-class uninitialized_iterator_adapter {
+class uninitialized_iterator_adaptor {
  public:
   using iterator_category = parlay::iterator_category_t<Iterator>;
   using difference_type = parlay::iterator_difference_type_t<Iterator>;
@@ -24,38 +24,39 @@ class uninitialized_iterator_adapter {
   using reference = std::add_lvalue_reference_t<value_type>;
   using pointer = std::add_pointer_t<value_type>;
 
-  uninitialized_iterator_adapter(Iterator it_) : it(it_) {}
+  explicit uninitialized_iterator_adaptor(Iterator it_) : it(it_) {}
 
   reference operator*() const { return it->value; }
 
-  pointer operator->() { return std::addressof(it->value); }
+  pointer operator->() const { return std::addressof(it->value); }
 
-  uninitialized_iterator_adapter& operator++() {
+  uninitialized_iterator_adaptor& operator++() {
     ++it;
     return *this;
   }
 
-  friend void swap(uninitialized_iterator_adapter& left, uninitialized_iterator_adapter& right) noexcept {
+  friend void swap(uninitialized_iterator_adaptor& left, uninitialized_iterator_adaptor& right) noexcept {
     std::swap(left.it, right.it);
   }
 
   // ------------------------ Enabled if input iterator ------------------------
 
   template<typename It = Iterator>
-  auto operator++(int) -> std::enable_if_t<parlay::is_input_iterator_v<It>, uninitialized_iterator_adapter> {
+  auto operator++(int)
+      -> std::enable_if_t<parlay::is_input_iterator_v<It>, uninitialized_iterator_adaptor> {
     auto tmp = *this;
     ++(*this);
     return tmp;
   }
 
   template<typename It = Iterator>
-  auto operator==(const uninitialized_iterator_adapter& other) const
+  auto operator==(const uninitialized_iterator_adaptor& other) const
       -> std::enable_if_t<parlay::is_input_iterator_v<It>, bool> {
     return it == other.it;
   }
 
   template<typename It = Iterator>
-  auto operator!=(const uninitialized_iterator_adapter& other) const
+  auto operator!=(const uninitialized_iterator_adaptor& other) const
       -> std::enable_if_t<parlay::is_input_iterator_v<It>, bool> {
     return it != other.it;
   }
@@ -64,18 +65,18 @@ class uninitialized_iterator_adapter {
 
   // Can't SFINAE special member functions so this is close enough until C++20
   template<typename It = Iterator, std::enable_if_t<parlay::is_forward_iterator_v<It>, int> = 0>
-  uninitialized_iterator_adapter() : it{} {}
+  uninitialized_iterator_adaptor() : it{} {}
 
   // ------------------------ Enabled if bidirectional iterator ------------------------
 
   template<typename It = Iterator>
-  auto operator--() -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adapter&> {
+  auto operator--() -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adaptor&> {
     it--;
     return *this;
   }
 
   template<typename It = Iterator>
-  auto operator--(int) -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adapter> {
+  auto operator--(int) -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adaptor> {
     auto tmp = *this;
     --(*this);
     return tmp;
@@ -85,14 +86,14 @@ class uninitialized_iterator_adapter {
 
   template<typename It = Iterator>
   auto operator+=(difference_type diff)
-      -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adapter&> {
+      -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adaptor&> {
     it += diff;
     return *this;
   }
 
   template<typename It = Iterator>
   auto operator+(difference_type diff) const
-      -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adapter> {
+      -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adaptor> {
     auto result = *this;
     result += diff;
     return result;
@@ -100,21 +101,21 @@ class uninitialized_iterator_adapter {
 
   template<typename It = Iterator>
   auto operator-=(difference_type diff)
-      -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adapter&> {
+      -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adaptor&> {
     it -= diff;
     return *this;
   }
 
   template<typename It = Iterator>
   auto operator-(difference_type diff) const
-      -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adapter> {
+      -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, uninitialized_iterator_adaptor> {
     auto result = *this;
     result -= diff;
     return result;
   }
 
   template<typename It = Iterator>
-  auto operator-(const uninitialized_iterator_adapter& other) const
+  auto operator-(const uninitialized_iterator_adaptor& other) const
       -> std::enable_if_t<parlay::is_bidirectional_iterator_v<It>, difference_type> {
     return it - other.it;
   }
@@ -125,25 +126,25 @@ class uninitialized_iterator_adapter {
   }
 
   template<typename It = Iterator>
-  auto operator<(const uninitialized_iterator_adapter& other) const
+  auto operator<(const uninitialized_iterator_adaptor& other) const
       -> std::enable_if_t<parlay::is_random_access_iterator_v<It>, bool> {
     return it < other.it;
   }
 
   template<typename It = Iterator>
-  auto operator<=(const uninitialized_iterator_adapter& other) const
+  auto operator<=(const uninitialized_iterator_adaptor& other) const
       -> std::enable_if_t<parlay::is_random_access_iterator_v<It>, bool> {
     return it <= other.it;
   }
 
   template<typename It = Iterator>
-  auto operator>(const uninitialized_iterator_adapter& other) const
+  auto operator>(const uninitialized_iterator_adaptor& other) const
       -> std::enable_if_t<parlay::is_random_access_iterator_v<It>, bool> {
     return it > other.it;
   }
 
   template<typename It = Iterator>
-  auto operator>=(const uninitialized_iterator_adapter& other) const
+  auto operator>=(const uninitialized_iterator_adaptor& other) const
       -> std::enable_if_t<parlay::is_random_access_iterator_v<It>, bool> {
     return it >= other.it;
   }

--- a/include/parlay/internal/uninitialized_sequence.h
+++ b/include/parlay/internal/uninitialized_sequence.h
@@ -152,7 +152,7 @@ class uninitialized_sequence {
   const_reverse_iterator crbegin() const { return std::make_reverse_iterator(cend()); }
   const_reverse_iterator crend() const { return std::make_reverse_iterator(cbegin()); }
   
-  void swap(uninitialized_sequence<T, Alloc>& other) {
+  void swap(uninitialized_sequence<T, Alloc>& other) noexcept {
     std::swap(impl.n, other.impl.n);
     std::swap(impl.data, other.impl.data);
   }

--- a/include/parlay/internal/uninitialized_storage.h
+++ b/include/parlay/internal/uninitialized_storage.h
@@ -18,7 +18,7 @@ namespace internal {
 template<typename T>
 class uninitialized_storage {
   using value_type = T;
-  typename std::aligned_storage<sizeof(T), alignof(T)>::type storage;
+  alignas(T) char storage [sizeof(T)];
 
  public:
   uninitialized_storage() {

--- a/include/parlay/primitives.h
+++ b/include/parlay/primitives.h
@@ -1279,7 +1279,7 @@ auto kth_smallest_copy(Range&& in, size_t k, Compare&& less = {}) {
   auto [offsets, total] = parlay::scan(sums);
   assert(total == n);
 
-  auto id = std::upper_bound(offsets.begin(), offsets.end(), k) - offsets.begin() - 1;
+  auto id = static_cast<size_t>(std::upper_bound(offsets.begin(), offsets.end(), k) - offsets.begin()) - 1;
   auto bucket_length = ((id == offsets.size() - 1) ? total : offsets[id+1]) - offsets[id];
 
   // Grab the contents of the bucket containing the k'th element.  Exclude the pivot

--- a/include/parlay/primitives.h
+++ b/include/parlay/primitives.h
@@ -1011,7 +1011,7 @@ auto flatten(sequence<sequence<T>>&& r) {
   size_t len = internal::scan_inplace(make_slice(offsets), plus<size_t>());
   auto res = sequence<T>::uninitialized(len);
   parallel_for(0, parlay::size(r), [&, it = std::begin(r)](size_t i) {
-    uninitialized_relocate_n(std::begin(res)+offsets[i], std::begin(it[i]), it[i].size());
+    parlay::uninitialized_relocate(std::begin(it[i]), std::end(it[i]), std::begin(res)+offsets[i]);
     clear_relocated(it[i]);
   });
   r.clear();

--- a/include/parlay/relocation.h
+++ b/include/parlay/relocation.h
@@ -20,146 +20,133 @@
 namespace parlay {
 
 /*
-    Relocation (a.k.a. "destructive move")
-
-  The relocation of object a into memory b is equivalent to a move
-  construction of a into b, followed by the destruction of what
-  remains at a. In other words, it is
-
-    new (b) T(std::move(*a));
-    a->~T();
-
-  For many types, however, this can be optimized by replacing it with just
-
-    std::memcpy(b, a, sizeof(T));
-
-   We call any such types trivially relocatable. This is clearly
-   true for any trivial type, but it also turns out to be true
-   for most other standard types, such as vectors, unique_ptrs,
-   and more. The key observation is that the only reason that
-   the move operations of these types is non-trivial is because
-   they must clear out the source object after moving from it.
-   If, however, the source object is treated as uninitialized
-   memory after relocation, then it does not have to be cleared
-   out, since its destructor will not run.
+   Range-based Relocation
 
    A strong motivating use case for relocation is in dynamically
    sized containers (e.g. vector, or parlay::sequence). When
-   performing a resize operation, one has to move all of the
-   contents of the old buffer into the new one, and destroy
-   the contents of the old buffer, like so (ignoring allocator
-   details)
+   performing a resize operation, one has to move the contents
+   of the old buffer into the new one, and destroy the contents
+   of the old buffer, like so (ignoring allocator details)
 
-   parallel_for(0, n, [&](size_t i) {
-     new (&new_buffer[i]) std::move(current_buffer[i]));
-     current_buffer[i].~value_type();
-   });
+     parallel_for(0, n, [&](size_t i) {
+       ::new (voidify(new_buffer[i])) std::move(current_buffer[i]));
+       std::destroy_at(std::addressof(current_buffer[i]));
+     });
 
-   This can be replaced with
+   If current_buffer and new_buffer contain the same type (should
+   always be true for a sequence container resize operation), then
+   this can be replaced with
 
-   parallel_for(0, n, [&](size_t i) {
-     uninitialized_relocate(&new_buffer[i], &current_buffer[i]);
-   });
+     parallel_for(0, n, [&](size_t i) {
+       relocate_at(std::addressof(current_buffer[i]), std::addressof(new_buffer[i]));
+     });
 
-   or even, for better performance yet
+   However, it may be even more efficient to move chunks of objects in parallel,
+   so for better performance, you can write
 
-   uninitialized_relocate_n(new_buffer, current_buffer, n);
+    uninitialized_relocate_n(current_buffer, n, new_buffer);
 
    The uninitialized_relocate functions will use the optimized
    memcpy-based approach for any types for which it is suitable,
    and otherwise, will fall back to the generic approach.
 */
 
-// Relocate the given range of n elements [from, from + n) into uninitialized
-// memory at [to, to + n), such that both the source and destination memory
-// were allocated by the given allocator.
-template<typename It1, typename It2, typename Alloc>
-inline void uninitialized_relocate_n_a(It1 to, It2 from, size_t n, Alloc& alloc) {
-  using T = typename std::iterator_traits<It1>::value_type;
-  static_assert(std::is_same_v<typename std::iterator_traits<It2>::value_type, T>);
-  static_assert(std::is_same_v<typename std::allocator_traits<Alloc>::value_type, T>);
+// Relocate from source to dest, which may be of different
+// (but compatible) types, which is equivalent to
+//
+//   ::new (voidify(dest)) T(std::move(source));
+//   std::destroy_at(std::addressof(source));
+//
+template<typename T, typename U>
+inline void relocate_or_move_and_destroy(T& source, U& dest) {
+  static_assert(std::is_constructible_v<U, std::add_rvalue_reference_t<T>>);
+  static_assert(std::is_destructible_v<T>);
 
-  constexpr bool trivially_relocatable = is_trivially_relocatable_v<T>;
-  constexpr bool trivial_alloc = is_trivial_allocator_v<Alloc, T>;
-  constexpr bool contiguous = is_contiguous_iterator_v<It1> && is_contiguous_iterator_v<It2>;
-  constexpr bool random_access = is_random_access_iterator_v<It1> && is_random_access_iterator_v<It2>;
+  if constexpr (std::is_same_v<T, U>) {
+    relocate_at(std::addressof(source), std::addressof(dest));
+  }
+  else {
+    PARLAY_ASSERT_UNINITIALIZED(dest);
+    ::new (voidify(dest)) T(std::move(source));
+    std::destroy_at(std::addressof(source));
+    PARLAY_ASSERT_UNINITIALIZED(source);
+  }
+}
 
-  // The most efficient scenario -- The objects are trivially relocatable, the allocator
-  // has no special behaviour, and the iterators point to contiguous memory so we can
-  // memcpy chunks of more than one T object at a time.
-  if constexpr (trivially_relocatable && contiguous && trivial_alloc) {
+// Relocate the given range of n elements [first, first + n) into uninitialized
+// memory at [result, result + n).
+template<typename InputIterator, typename Size, typename NoThrowForwardIterator>
+inline std::pair<InputIterator, NoThrowForwardIterator> uninitialized_relocate_n(
+    InputIterator first, Size n, NoThrowForwardIterator result) {
+
+  static_assert(is_input_iterator_v<InputIterator>);
+  static_assert(is_forward_iterator_v<NoThrowForwardIterator>);
+
+  using T = iterator_value_type_t<NoThrowForwardIterator>;
+
+  constexpr bool trivially_relocatable = is_trivially_relocatable_v<T> &&
+                                         std::is_same_v<iterator_value_type_t<InputIterator>, T>;
+  constexpr bool contiguous = is_contiguous_iterator_v<InputIterator> &&
+                              is_contiguous_iterator_v<NoThrowForwardIterator>;
+  constexpr bool random_access = is_random_access_iterator_v<InputIterator> &&
+                                 is_random_access_iterator_v<NoThrowForwardIterator>;
+
+  // The most efficient scenario -- The objects are trivially relocatable and the iterators
+  // point to contiguous memory so, we can memcpy chunks of more than one T object at a time.
+  if constexpr (contiguous && trivially_relocatable) {
     constexpr size_t chunk_size = 1024 * sizeof(size_t) / sizeof(T);
     const size_t n_chunks = (n + chunk_size - 1) / chunk_size;
     parallel_for(0, n_chunks, [&](size_t i) {
       size_t n_objects = (std::min)(chunk_size, n - i * chunk_size);
+#if defined(__cpp_lib_trivially_relocatable)
+      std::uninitialized_relocate_n(first + i * chunk_size, n_objects, result + i * chunk_size);
+#else
       size_t n_bytes = sizeof(T) * n_objects;
-      void* src = static_cast<void*>(std::addressof(*(from + i * chunk_size)));
-      void* dest = static_cast<void*>(std::addressof(*(to + i * chunk_size)));
+      void* src = voidify(*(first + i * chunk_size));
+      void* dest = voidify(*(result + i * chunk_size));
       std::memcpy(dest, src, n_bytes);
+#endif
     }, 1);
-  // The next best thing -- If the objects are trivially relocatable and the allocator
-  // has no special behaviour, so long as the iterators are random access, we can still
-  // relocate everything in parallel, just not by memcpying multiple objects at a time
-  } else if constexpr (trivially_relocatable && random_access && trivial_alloc) {
-    constexpr size_t chunk_size = 1024 * sizeof(size_t) / sizeof(T);
-    const size_t n_chunks = (n + chunk_size - 1) / chunk_size;
-    parallel_for(0, n_chunks, [&](size_t i) {
-      for (size_t j = 0; j < chunk_size && (j + i *chunk_size < n); j++) {
-        void* src = static_cast<void*>(std::addressof(from[j + i * chunk_size]));
-        void* dest = static_cast<void*>(std::addressof(to[j + i * chunk_size]));
-        std::memcpy(dest, src, sizeof(T));
-      }
-    }, 1);
+    return {first + n, result + n};
   }
-  // The iterators are not random access, but we can still relocate, just not in parallel
-  else if constexpr (trivially_relocatable && trivial_alloc) {
-    for (size_t i = 0; i < n; i++) {
-      std::memcpy(std::addressof(*to), std::addressof(*from), sizeof(T));
-      to++;
-      from++;
-    }
-  }
-  // After this point, the object can not be trivially relocated, either because it is not
-  // trivially relocatable, or because the allocator has specialized behaviour. We now fall
-  // back to just doing a "destructive move" manually.
+  // The next best thing -- if the iterators are random access we can still relocate everything in
+  // parallel, just not by memcpying multiple objects at a time
   else if constexpr (random_access) {
-    static_assert(std::is_move_constructible<T>::value);
-    static_assert(std::is_destructible<T>::value);
-    parallel_for(0, n, [&](size_t i) {
-      PARLAY_ASSERT_UNINITIALIZED(to[i]);
-      std::allocator_traits<Alloc>::construct(alloc, std::addressof(to[i]), std::move(from[i]));
-      std::allocator_traits<Alloc>::destroy(alloc, std::addressof(from[i]));
-      PARLAY_ASSERT_UNINITIALIZED(from[i]);
+    parallel_for(0, n, [&](size_t i){
+      relocate_or_move_and_destroy(first[i], result[i]);
     });
+    return {first + n, result + n};
   }
-  // The worst case. No parallelism and no fast relocation.
+  // No parallelism allowed!
   else {
-    static_assert(std::is_move_constructible<T>::value);
-    static_assert(std::is_destructible<T>::value);
-    for (size_t i = 0; i < n; i++) {
-      PARLAY_ASSERT_UNINITIALIZED(*to);
-      std::allocator_traits<Alloc>::construct(alloc, std::addressof(*to), std::move(*from));
-      std::allocator_traits<Alloc>::destroy(alloc, std::addressof(*from));
-      PARLAY_ASSERT_UNINITIALIZED(*from);
-      to++;
-      from++;
+    for (; n > 0; ++result, (void)++first, --n) {
+      // Note: Dereferencing result is UB since it points to uninitialized memory, but
+      // I don't think that is avoidable until we get C++20 with std::to_address.
+      relocate_or_move_and_destroy(*first, *result);
     }
+    return {first, result};
   }
 }
 
-// Relocate the given range of n elements [from, from + n) into uninitialized
-// memory at [to, to + n). Relocation is done as if the memory was allocated
-// by a standard allocator (e.g. std::allocator, parlay::allocator, malloc)
-//
-// For an allocator-aware version that respects the construction and destruction
-// behaviour of the allocator, use uninitialized_relocate_n_a.
-template<typename Iterator1, typename Iterator2>
-inline void uninitialized_relocate_n(Iterator1 to, Iterator2 from, size_t n) {
-  using T = typename std::iterator_traits<Iterator1>::value_type;
-  std::allocator<T> a;
-  uninitialized_relocate_n_a(to, from, n, a);
+
+template<typename InputIterator, typename NoThrowForwardIterator>
+NoThrowForwardIterator uninitialized_relocate(InputIterator first, InputIterator last, NoThrowForwardIterator result) {
+  static_assert(parlay::is_input_iterator_v<InputIterator>);
+  static_assert(parlay::is_forward_iterator_v<NoThrowForwardIterator>);
+
+  if constexpr (is_random_access_iterator_v<InputIterator>) {
+    return parlay::uninitialized_relocate_n(first, std::distance(first, last), result).second;
+  }
+  else {
+    for (; first != last; ++result, (void)++first) {
+      // Note: Dereferencing result is UB since it points to uninitialized memory, but
+      // I don't think that is avoidable until we get C++20 with std::to_address.
+      relocate_or_move_and_destroy(*first, *result);
+    }
+    return result;
+  }
 }
 
-}
+}  // namespace parlay
 
 #endif  // PARLAY_RELOCATION_H_

--- a/include/parlay/type_traits.h
+++ b/include/parlay/type_traits.h
@@ -272,7 +272,7 @@ struct is_trivial_allocator<std::allocator<T>, T> : std::true_type {};
 */
 
 // Standard language support for trivially relocatable (currently P1144)
-#if defined(__cpp_impl_trivially_relocatable)
+#if defined(__cpp_lib_trivially_relocatable)
 
 template<typename T>
 using is_trivially_relocatable = std::is_trivially_relocatable<T>;

--- a/include/parlay/type_traits.h
+++ b/include/parlay/type_traits.h
@@ -413,7 +413,7 @@ PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::vector<T>);
 // std::string or std::vector, but those look good.
 #elif defined(_MSC_VER)
 
-template<typename T>
+template<>
 PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::string);
 
 template<typename T>

--- a/include/parlay/type_traits.h
+++ b/include/parlay/type_traits.h
@@ -15,10 +15,19 @@
 #include <array>
 #include <deque>
 #include <functional>
+#include <forward_list>
+#include <list>
+#include <map>
 #include <memory>
 #include <optional>
+#include <queue>
+#include <set>
+#include <stack>
+#include <string>
 #include <type_traits>
 #include <tuple>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>       // IWYU pragma: keep
 #include <variant>
 
@@ -361,20 +370,20 @@ PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::forward_list<T>);
 template<typename T>
 PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::vector<T>);
 
-template<typename T>
-PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::string<T>);
+template<>
+PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::string);
 
 template<typename T>
 PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::unordered_set<T>);
 
-template<typename T>
-PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::unordered_map<T>);
+template<typename K, typename V>
+PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::unordered_map<K, V>);
 
 template<typename T>
 PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::unordered_multiset<T>);
 
-template<typename T>
-PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::unordered_multimap<T>);
+template<typename K, typename V>
+PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::unordered_multimap<K, V>);
 
 template<typename T>
 PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::stack<T>);
@@ -405,7 +414,7 @@ PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::vector<T>);
 #elif defined(_MSC_VER)
 
 template<typename T>
-PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::string<T>);
+PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::string);
 
 template<typename T>
 PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(std::vector<T>);

--- a/include/parlay/type_traits.h
+++ b/include/parlay/type_traits.h
@@ -36,6 +36,14 @@ struct type_identity {
 template<typename T>
 using type_identity_t = typename type_identity<T>::type;
 
+// Provides the member type equivalent to T with its cv-ref qualifiers removed
+template<typename T>
+struct remove_cvref : type_identity<std::remove_cv_t<std::remove_reference_t<T>>> { };
+
+// Equal to T with its cv-ref qualifiers removed
+template<typename T>
+using remove_cvref_t = typename remove_cvref<T>::type;
+
 // Given a pointer-to-member (object or function), returns
 // the type of the class in which the member lives
 template<typename T>
@@ -236,8 +244,8 @@ struct is_trivial_allocator<std::allocator<T>, T> : std::true_type {};
     to an object of type T, and a pointer q to uninitialized memory
     large enough for an object of type T, then
 
-      new (q) T(std::move(*p));
-      p->~T();
+      ::new (voidify(*q)) T(std::move(*p));
+      std::destroy_at(p);
 
     is equivalent to
 

--- a/test/test_counting_sort.cpp
+++ b/test/test_counting_sort.cpp
@@ -92,13 +92,6 @@ TEST(TestCountingSort, TestCountingSortInplaceNonContiguous) {
   ASSERT_TRUE(std::is_sorted(std::begin(s), std::end(s)));
 }
 
-namespace parlay {
-// Specialize std::unique_ptr to be considered trivially relocatable
-template<typename T>
-struct is_trivially_relocatable<std::unique_ptr<T>> : public std::true_type {
-};
-}
-
 TEST(TestCountingSort, TestCountingSortInplaceUniquePtr) {
   auto s = parlay::tabulate(100000, [](long long i) {
     return std::make_unique<long long>((51 * i + 61) % num_buckets);

--- a/test/test_relocate.cpp
+++ b/test/test_relocate.cpp
@@ -4,16 +4,13 @@
 #include <vector>
 #include <deque>
 
+#include <parlay/range.h>
 #include <parlay/relocation.h>
 #include <parlay/type_traits.h>
 #include <parlay/utilities.h>
 
-// Launder is not available in some older compilers
-#ifdef __cpp_lib_launder
-#define LAUNDER(x) std::launder((x))
-#else
-#define LAUNDER(x) (x)
-#endif
+#include <parlay/internal/uninitialized_iterator.h>
+
 
 // A type that is not trivially relocatable because
 // it keeps a pointer to an object inside itself
@@ -23,6 +20,7 @@ struct NotTriviallyRelocatable {
   explicit NotTriviallyRelocatable(int _x) : x(_x), px(&x) { }
   NotTriviallyRelocatable(const NotTriviallyRelocatable& other) : x(other.x), px(&x) { }
   NotTriviallyRelocatable(NotTriviallyRelocatable&& other) noexcept : x(other.x), px(&x) { }
+  int get() const { assert(px == &x); return *px; }
 };
 
 // A type that is trivially relocatable because it is
@@ -33,11 +31,12 @@ struct TriviallyRelocatable {
   TriviallyRelocatable(const TriviallyRelocatable&) = default;
   TriviallyRelocatable(TriviallyRelocatable&&) = default;
   ~TriviallyRelocatable() = default;
+  int get() const { return x; }
 };
 
 // A type that we annotate as trivially relocatable,
 // even though it is not deducible as such by the compiler
-struct MyTriviallyRelocatable {
+struct PARLAY_TRIVIALLY_RELOCATABLE MyTriviallyRelocatable {
   int* x;
   explicit MyTriviallyRelocatable(int _x) : x(new int(_x)) { }
   MyTriviallyRelocatable(const MyTriviallyRelocatable& other) : x(nullptr) {
@@ -45,7 +44,7 @@ struct MyTriviallyRelocatable {
       x = new int(*(other.x));
     }
   }
-  MyTriviallyRelocatable(MyTriviallyRelocatable&& other) : x(other.x) { other.x = nullptr; }
+  MyTriviallyRelocatable(MyTriviallyRelocatable&& other) noexcept : x(other.x) { other.x = nullptr; }
   ~MyTriviallyRelocatable() {
     if (x != nullptr) {
       *x = -1;
@@ -53,15 +52,18 @@ struct MyTriviallyRelocatable {
       x = nullptr;
     }
   }
+  int get() const { return *x; }
 };
 
+#if defined(PARLAY_MUST_SPECIALIZE_IS_TRIVIALLY_RELOCATABLE)
 namespace parlay {
   
 // Mark the type MyTriviallyRelocatable as trivially relocatable
 template<>
-struct is_trivially_relocatable<MyTriviallyRelocatable> : public std::true_type { };
+PARLAY_ASSUME_TRIVIALLY_RELOCATABLE(MyTriviallyRelocatable);
   
 }
+#endif
 
 
 static_assert(!parlay::is_trivially_relocatable_v<NotTriviallyRelocatable>);
@@ -70,285 +72,140 @@ static_assert(parlay::is_trivially_relocatable_v<MyTriviallyRelocatable>);
 
 
 TEST(TestRelocate, TestNotTriviallyRelocatable) {
-  std::aligned_storage<sizeof(NotTriviallyRelocatable), alignof(NotTriviallyRelocatable)>::type a, b;
-  NotTriviallyRelocatable* from = LAUNDER(reinterpret_cast<NotTriviallyRelocatable*>(&a));
-  NotTriviallyRelocatable* to = LAUNDER(reinterpret_cast<NotTriviallyRelocatable*>(&b));
-  // -- Both from and to point to uninitialized memory
+  parlay::uninitialized<NotTriviallyRelocatable> a, b;
+  NotTriviallyRelocatable* source = &a.value;
+  NotTriviallyRelocatable* dest = &b.value;
+  // -- Both source and dest point to uninitialized memory
   
-  new (from) NotTriviallyRelocatable(42);
-  ASSERT_EQ(from->x, 42);
-  ASSERT_EQ(from->px, &(from->x));
-  // -- Now from points to a valid object, and to points to uninitialized memory
+  ::new (source) NotTriviallyRelocatable(42);
+  ASSERT_EQ(source->x, 42);
+  ASSERT_EQ(source->px, &(source->x));
+  // -- Now source points to a valid object, and dest points to uninitialized memory
 
-  parlay::relocate_at(from, to);
-  ASSERT_EQ(to->x, 42);
-  ASSERT_EQ(to->px, &(to->x));
-  // -- Now to points to a valid object, and from points to uninitialized memory
-  
-  to->~NotTriviallyRelocatable();
-  // -- Both from and to point to uninitialized memory
+  parlay::relocate_at(source, dest);
+  ASSERT_EQ(dest->x, 42);
+  ASSERT_EQ(dest->px, &(dest->x));
+  // -- Now dest points to a valid object, and source points to uninitialized memory
+
+  std::destroy_at(dest);
+  // -- Both source and dest point to uninitialized memory
 }
 
 
 TEST(TestRelocate, TestTriviallyRelocatable) {
-  std::aligned_storage<sizeof(TriviallyRelocatable), alignof(TriviallyRelocatable)>::type a, b;
-  TriviallyRelocatable* from = LAUNDER(reinterpret_cast<TriviallyRelocatable*>(&a));
-  TriviallyRelocatable* to = LAUNDER(reinterpret_cast<TriviallyRelocatable*>(&b));
-  // -- Both from and to point to uninitialized memory
+  parlay::uninitialized<TriviallyRelocatable> a, b;
+  TriviallyRelocatable* source = &a.value;
+  TriviallyRelocatable* dest = &b.value;
+  // -- Both source and dest point to uninitialized memory
   
-  new (from) TriviallyRelocatable(42);
-  ASSERT_EQ(from->x, 42);
-  // -- Now from points to a valid object, and to points to uninitialized memory
+  ::new (source) TriviallyRelocatable(42);
+  ASSERT_EQ(source->x, 42);
+  // -- Now source points to a valid object, and dest points to uninitialized memory
 
-  parlay::relocate_at(from, to);
-  ASSERT_EQ(to->x, 42);
-  // -- Now to points to a valid object, and from points to uninitialized memory
-  
-  to->~TriviallyRelocatable();
-  // -- Both from and to point to uninitialized memory
+  parlay::relocate_at(source, dest);
+  ASSERT_EQ(dest->x, 42);
+  // -- Now dest points to a valid object, and source points to uninitialized memory
+
+  std::destroy_at(dest);
+  // -- Both source and dest point to uninitialized memory
 }
 
 
 TEST(TestRelocate, TestCustomTriviallyRelocatable) {
-  std::aligned_storage<sizeof(MyTriviallyRelocatable), alignof(MyTriviallyRelocatable)>::type a, b;
-  MyTriviallyRelocatable* from = LAUNDER(reinterpret_cast<MyTriviallyRelocatable*>(&a));
-  MyTriviallyRelocatable* to = LAUNDER(reinterpret_cast<MyTriviallyRelocatable*>(&b));
-  // -- Both from and to point to uninitialized memory
-  
-  new (from) MyTriviallyRelocatable(42);
-  ASSERT_EQ(*(from->x), 42);
-  // -- Now from points to a valid object, and to points to uninitialized memory
+  parlay::uninitialized<MyTriviallyRelocatable> a, b;
+  MyTriviallyRelocatable* source = &a.value;
+  MyTriviallyRelocatable* dest = &b.value;
+  // -- Both source and dest point to uninitialized memory
 
-  parlay::relocate_at(from, to);
-  ASSERT_EQ(*(to->x), 42);
-  // -- Now to points to a valid object, and from points to uninitialized memory
+  ::new (source) MyTriviallyRelocatable(42);
+  ASSERT_EQ(*(source->x), 42);
+  // -- Now source points to a valid object, and dest points to uninitialized memory
+
+  parlay::relocate_at(source, dest);
+  ASSERT_EQ(*(dest->x), 42);
+  // -- Now dest points to a valid object, and source points to uninitialized memory
   
-  to->~MyTriviallyRelocatable();
-  // -- Both from and to point to uninitialized memory
+  std::destroy_at(dest);
+  // -- Both source and dest point to uninitialized memory
 }
 
 
-TEST(TestRelocate, TestNotTriviallyRelocatableArray) {
-  constexpr int N = 100000;
-  std::vector<std::aligned_storage<sizeof(NotTriviallyRelocatable), alignof(NotTriviallyRelocatable)>::type> a(N), b(N);
-  NotTriviallyRelocatable* from = LAUNDER(reinterpret_cast<NotTriviallyRelocatable*>(a.data()));
-  NotTriviallyRelocatable* to = LAUNDER(reinterpret_cast<NotTriviallyRelocatable*>(b.data()));
-  // -- Both from and to point to uninitialized memory
-  
-  for (int i = 0; i < N; i++) {
-    new (&from[i]) NotTriviallyRelocatable(i);
-  }
-  for (int i = 0; i < N; i++) {
-    ASSERT_EQ(from[i].x, i);
-    ASSERT_EQ(from[i].px, &(from[i].x));
-  }
-  // -- Now from points to an array of valid objects, and to points to uninitialized memory
-  
-  parlay::uninitialized_relocate_n(to, from, N);
-  for (int i = 0; i < N; i++) {
-    ASSERT_EQ(to[i].x, i);
-    ASSERT_EQ(to[i].px, &(to[i].x));
-  }
-  // -- Now to points to an array of valid objects, and from points to uninitialized memory
-  
-  for (int i = 0; i < N; i++) {
-    to[i].~NotTriviallyRelocatable();
-  }
-  // -- Both from and to point to uninitialized memory
-}
+template <typename TestParams>
+class TestRangeRelocate : public testing::Test { };
 
-TEST(TestRelocate, TestTriviallyRelocatableArray) {
-  constexpr int N = 100000;
-  std::vector<std::aligned_storage<sizeof(TriviallyRelocatable), alignof(TriviallyRelocatable)>::type> a(N), b(N);
-  TriviallyRelocatable* from = LAUNDER(reinterpret_cast<TriviallyRelocatable*>(a.data()));
-  TriviallyRelocatable* to = LAUNDER(reinterpret_cast<TriviallyRelocatable*>(b.data()));
-  // -- Both from and to point to uninitialized memory
-  
-  for (int i = 0; i < N; i++) {
-    new (&from[i]) TriviallyRelocatable(i);
-  }
-  for (int i = 0; i < N; i++) {
-    ASSERT_EQ(from[i].x, i);
-  }
-  // -- Now from points to an array of valid objects, and to points to uninitialized memory
-  
-  parlay::uninitialized_relocate_n(to, from, N);
-  for (int i = 0; i < N; i++) {
-    ASSERT_EQ(to[i].x, i);
-  }
-  // -- Now to points to an array of valid objects, and from points to uninitialized memory
-  
-  for (int i = 0; i < N; i++) {
-    to[i].~TriviallyRelocatable();
-  }
-  // -- Both from and to point to uninitialized memory
-}
-
-TEST(TestRelocate, TestCustomTriviallyRelocatableArray) {
-  constexpr int N = 100000;
-  std::vector<std::aligned_storage<sizeof(MyTriviallyRelocatable), alignof(MyTriviallyRelocatable)>::type> a(N), b(N);
-  MyTriviallyRelocatable* from = LAUNDER(reinterpret_cast<MyTriviallyRelocatable*>(a.data()));
-  MyTriviallyRelocatable* to = LAUNDER(reinterpret_cast<MyTriviallyRelocatable*>(b.data()));
-  // -- Both from and to point to uninitialized memory
-  
-  for (int i = 0; i < N; i++) {
-    new (&from[i]) MyTriviallyRelocatable(i);
-  }
-  for (int i = 0; i < N; i++) {
-    ASSERT_EQ(*(from[i].x), i);
-  }
-  // -- Now from points to an array of valid objects, and to points to uninitialized memory
-  
-  parlay::uninitialized_relocate_n(to, from, N);
-  for (size_t i = 0; i < N; i++) {
-    ASSERT_EQ(*(to[i].x), i);
-  }
-  // -- Now to points to an array of valid objects, and from points to uninitialized memory
-  
-  for (int i = 0; i < N; i++) {
-    to[i].~MyTriviallyRelocatable();
-  }
-  // -- Both from and to point to uninitialized memory
-}
-
-TEST(TestRelocate, TestRelocatableNonContiguousArray) {
-  constexpr int N = 100000;
-  std::deque<std::aligned_storage<sizeof(MyTriviallyRelocatable), alignof(MyTriviallyRelocatable)>::type> a(N), b(N);
-  auto from = std::begin(a);
-  auto to = std::begin(b);
-  // -- Both from and to point to uninitialized memory
-
-  static_assert(!parlay::is_contiguous_iterator_v<decltype(from)>);
-  static_assert(!parlay::is_contiguous_iterator_v<decltype(to)>);
-
-  auto get_from = [&](auto i) {
-    return LAUNDER(reinterpret_cast<MyTriviallyRelocatable*>(&from[i]));
-  };
-
-  auto get_to = [&](auto i) {
-    return LAUNDER(reinterpret_cast<MyTriviallyRelocatable*>(&to[i]));
-  };
-
-  for (int i = 0; i < N; i++) {
-    new (get_from(i)) MyTriviallyRelocatable(i);
-  }
-  for (int i = 0; i < N; i++) {
-    ASSERT_EQ(*(get_from(i)->x), i);
-  }
-  // -- Now from points to an array of valid objects, and to points to uninitialized memory
-
-  parlay::uninitialized_relocate_n(to, from, N);
-  for (int i = 0; i < N; i++) {
-    ASSERT_EQ(*(get_to(i)->x), i);
-  }
-  // -- Now to points to an array of valid objects, and from points to uninitialized memory
-
-  for (int i = 0; i < N; i++) {
-    get_to(i)->~MyTriviallyRelocatable();
-  }
-  // -- Both from and to point to uninitialized memory
-}
-
-TEST(TestRelocate, TestRelocatableNonRandomAccessArray) {
-  constexpr int N = 1000;
-  std::list<std::aligned_storage<sizeof(MyTriviallyRelocatable), alignof(MyTriviallyRelocatable)>::type> a(N), b(N);
-  auto from = std::begin(a);
-  auto to = std::begin(b);
-  // -- Both from and to point to uninitialized memory
-
-  static_assert(!parlay::is_random_access_iterator_v<decltype(from)>);
-  static_assert(!parlay::is_random_access_iterator_v<decltype(to)>);
-
-  auto get_from = [&](auto i) {
-    auto it = from;
-    std::advance(it, i);
-    return LAUNDER(reinterpret_cast<MyTriviallyRelocatable*>(&(*it)));
-  };
-
-  auto get_to = [&](auto i) {
-    auto it = to;
-    std::advance(it, i);
-    return LAUNDER(reinterpret_cast<MyTriviallyRelocatable*>(&(*it)));
-  };
-
-  for (int i = 0; i < N; i++) {
-    new (get_from(i)) MyTriviallyRelocatable(i);
-  }
-  for (int i = 0; i < N; i++) {
-    ASSERT_EQ(*(get_from(i)->x), i);
-  }
-  // -- Now from points to an array of valid objects, and to points to uninitialized memory
-
-  parlay::uninitialized_relocate_n(to, from, N);
-  for (int i = 0; i < N; i++) {
-    ASSERT_EQ(*(get_to(i)->x), i);
-  }
-  // -- Now to points to an array of valid objects, and from points to uninitialized memory
-
-  for (int i = 0; i < N; i++) {
-    get_to(i)->~MyTriviallyRelocatable();
-  }
-  // -- Both from and to point to uninitialized memory
-}
-
-// An uninitialized memory container that holds an object of type T,
-// but does not construct it or destroy it. It will move it, though.
-template<typename T>
-struct NonRelocatableStorage {
-  char storage[sizeof(T)];
-  NonRelocatableStorage() { }
-  NonRelocatableStorage(NonRelocatableStorage&& other) {
-    new (get_storage()) T(std::move(*other.get_storage()));
-  }
-  T* get_storage() {
-    return LAUNDER(reinterpret_cast<T*>(storage));
-  }
-  ~NonRelocatableStorage() { }  // Non-trivial destructor prevents it from being trivially relocatable
+template<typename Container, typename T, bool UseIterator>
+struct RangeRelocateTestParams {
+  using container = Container;
+  using value_type = T;
+  static constexpr inline bool use_iterator = UseIterator;
 };
 
+// Test on the cartesian product of <Vector, Deque, List> x
+//                                  <TriviallyRelocatable, NotTriviallyRelocatable, MyTriviallyRelocatable> x
+//                                  <begin/end version, _n version>
+using TestTypes = ::testing::Types<
+    RangeRelocateTestParams<std::vector<parlay::uninitialized<TriviallyRelocatable>>, TriviallyRelocatable, true>,
+    RangeRelocateTestParams<std::vector<parlay::uninitialized<NotTriviallyRelocatable>>, NotTriviallyRelocatable, true>,
+    RangeRelocateTestParams<std::vector<parlay::uninitialized<MyTriviallyRelocatable>>, MyTriviallyRelocatable, true>,
+    RangeRelocateTestParams<std::vector<parlay::uninitialized<TriviallyRelocatable>>, TriviallyRelocatable, false>,
+    RangeRelocateTestParams<std::vector<parlay::uninitialized<NotTriviallyRelocatable>>, NotTriviallyRelocatable, false>,
+    RangeRelocateTestParams<std::vector<parlay::uninitialized<MyTriviallyRelocatable>>, MyTriviallyRelocatable, false>,
 
-TEST(TestRelocate, TestNonRelocatableNonRandomAccessArray) {
-  constexpr int N = 1000;
-  std::list<NonRelocatableStorage<NotTriviallyRelocatable>> a(N), b(N);
-  auto from = std::begin(a);
-  auto to = std::begin(b);
+    RangeRelocateTestParams<std::deque<parlay::uninitialized<TriviallyRelocatable>>, TriviallyRelocatable, true>,
+    RangeRelocateTestParams<std::deque<parlay::uninitialized<NotTriviallyRelocatable>>, NotTriviallyRelocatable, true>,
+    RangeRelocateTestParams<std::deque<parlay::uninitialized<MyTriviallyRelocatable>>, MyTriviallyRelocatable, true>,
+    RangeRelocateTestParams<std::deque<parlay::uninitialized<TriviallyRelocatable>>, TriviallyRelocatable, false>,
+    RangeRelocateTestParams<std::deque<parlay::uninitialized<NotTriviallyRelocatable>>, NotTriviallyRelocatable, false>,
+    RangeRelocateTestParams<std::deque<parlay::uninitialized<MyTriviallyRelocatable>>, MyTriviallyRelocatable, false>,
 
-  static_assert(!parlay::is_random_access_iterator_v<decltype(from)>);
-  static_assert(!parlay::is_random_access_iterator_v<decltype(to)>);
-  static_assert(!parlay::is_trivially_relocatable_v<NonRelocatableStorage<NotTriviallyRelocatable>>);
+    RangeRelocateTestParams<std::list<parlay::uninitialized<TriviallyRelocatable>>, TriviallyRelocatable, true>,
+    RangeRelocateTestParams<std::list<parlay::uninitialized<NotTriviallyRelocatable>>, NotTriviallyRelocatable, true>,
+    RangeRelocateTestParams<std::list<parlay::uninitialized<MyTriviallyRelocatable>>, MyTriviallyRelocatable, true>,
+    RangeRelocateTestParams<std::list<parlay::uninitialized<TriviallyRelocatable>>, TriviallyRelocatable, false>,
+    RangeRelocateTestParams<std::list<parlay::uninitialized<NotTriviallyRelocatable>>, NotTriviallyRelocatable, false>,
+    RangeRelocateTestParams<std::list<parlay::uninitialized<MyTriviallyRelocatable>>, MyTriviallyRelocatable, false>
+>;
 
-  // -- Both from and to point to uninitialized memory
+TYPED_TEST_SUITE(TestRangeRelocate, TestTypes);
 
-  auto get_from = [&](auto i) {
-    auto it = from;
-    std::advance(it, i);
-    return it->get_storage();
-  };
+TYPED_TEST(TestRangeRelocate, TestTriviallyRelocatable) {
+  constexpr int N = 100000;
+  typename TypeParam::container source(N), dest(N);
 
-  auto get_to = [&](auto i) {
-    auto it = to;
-    std::advance(it, i);
-    return it->get_storage();
-  };
+  using T = typename TypeParam::value_type;
+  static_assert(std::is_same_v<typename TypeParam::container::value_type, parlay::uninitialized<T>>);
 
-  for (int i = 0; i < N; i++) {
-    new (get_from(i)) NotTriviallyRelocatable(i);
+  // Initialize elements of source
+  auto s_it = source.begin();
+  for (int i = 0; i < N; i++, ++s_it) {
+    ::new (&(s_it->value)) T(i);
+    ASSERT_EQ(s_it->value.get(), i);
   }
-  for (int i = 0; i < N; i++) {
-    ASSERT_EQ((get_from(i)->x), i);
-    ASSERT_EQ(get_from(i)->px, &(get_from(i)->x));
-  }
-  // -- Now from points to an array of valid objects, and to points to uninitialized memory
 
-  parlay::uninitialized_relocate_n(to, from, N);
-  for (int i = 0; i < N; i++) {
-    ASSERT_EQ((get_to(i)->x), i);
-    ASSERT_EQ(get_to(i)->px, &(get_to(i)->x));
-  }
-  // -- Now to points to an array of valid objects, and from points to uninitialized memory
+  // -- Now source points to a range of valid objects, and dest points to a range of uninitialized objects
 
-  for (int i = 0; i < N; i++) {
-    get_to(i)->~NotTriviallyRelocatable();
+  auto source_begin = parlay::internal::uninitialized_iterator_adapter{source.begin()};
+  auto source_end = parlay::internal::uninitialized_iterator_adapter{source.end()};
+  auto dest_begin = parlay::internal::uninitialized_iterator_adapter{dest.begin()};
+  auto dest_end = parlay::internal::uninitialized_iterator_adapter{dest.end()};
+
+  if constexpr (TypeParam::use_iterator) {
+    auto result = parlay::uninitialized_relocate(source_begin, source_end, dest_begin);
+    ASSERT_EQ(result, dest_end);
   }
-  // -- Both from and to point to uninitialized memory
+  else {
+    auto [s_result, d_result] = parlay::uninitialized_relocate_n(source_begin, N, dest_begin);
+    ASSERT_EQ(s_result, source_end);
+    ASSERT_EQ(d_result, dest_end);
+  }
+
+  // -- Now dest points to a range of valid objects, and source points to a range of uninitialized objects
+
+  auto d_it = dest.begin();
+  for (int i = 0; i < N; i++, ++d_it) {
+    ASSERT_EQ(d_it->value.get(), i);
+    std::destroy_at(&(d_it->value));
+  }
+
+  // -- Both source and dest point to uninitialized memory
 }

--- a/test/test_relocate.cpp
+++ b/test/test_relocate.cpp
@@ -26,7 +26,7 @@ struct NotTriviallyRelocatable {
 };
 
 // A type that is trivially relocatable because it is
-// trivially movable and trivally destructible
+// trivially movable and trivially destructible
 struct TriviallyRelocatable {
   int x;
   explicit TriviallyRelocatable(int _x) : x(_x) { }
@@ -79,8 +79,8 @@ TEST(TestRelocate, TestNotTriviallyRelocatable) {
   ASSERT_EQ(from->x, 42);
   ASSERT_EQ(from->px, &(from->x));
   // -- Now from points to a valid object, and to points to uninitialized memory
-  
-  parlay::uninitialized_relocate(to, from);
+
+  parlay::relocate_at(from, to);
   ASSERT_EQ(to->x, 42);
   ASSERT_EQ(to->px, &(to->x));
   // -- Now to points to a valid object, and from points to uninitialized memory
@@ -99,8 +99,8 @@ TEST(TestRelocate, TestTriviallyRelocatable) {
   new (from) TriviallyRelocatable(42);
   ASSERT_EQ(from->x, 42);
   // -- Now from points to a valid object, and to points to uninitialized memory
-  
-  parlay::uninitialized_relocate(to, from);
+
+  parlay::relocate_at(from, to);
   ASSERT_EQ(to->x, 42);
   // -- Now to points to a valid object, and from points to uninitialized memory
   
@@ -118,8 +118,8 @@ TEST(TestRelocate, TestCustomTriviallyRelocatable) {
   new (from) MyTriviallyRelocatable(42);
   ASSERT_EQ(*(from->x), 42);
   // -- Now from points to a valid object, and to points to uninitialized memory
-  
-  parlay::uninitialized_relocate(to, from);
+
+  parlay::relocate_at(from, to);
   ASSERT_EQ(*(to->x), 42);
   // -- Now to points to a valid object, and from points to uninitialized memory
   

--- a/test/test_sample_sort.cpp
+++ b/test/test_sample_sort.cpp
@@ -101,12 +101,6 @@ TEST(TestSampleSort, TestSortInplaceUncopyable) {
   ASSERT_TRUE(std::is_sorted(std::begin(s), std::end(s)));
 }
 
-namespace parlay {
-  // Specialize std::unique_ptr to be considered trivially relocatable
-  template<typename T>
-  struct is_trivially_relocatable<std::unique_ptr<T>> : public std::true_type { };
-}
-
 TEST(TestSampleSort, TestSortInplaceUniquePtr) {
   auto s = parlay::tabulate(100000, [](long long int i) {
     return std::make_unique<long long int>((50021 * i + 61) % (1 << 20));


### PR DESCRIPTION
[Relocation](https://quuxplusone.github.io/blog/2018/07/18/announcing-trivially-relocatable/) now mostly follows the API proposed in [P1144](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p1144r9.html). Parlay will also defer the implementation of relocation operations to the compiler/library if they are present, which currently works on Arthur O'Dwyer's LLVM fork [here](https://github.com/Quuxplusone/llvm-project).