### PR TITLE
thread_id_pool.h: mark variable as [[maybe_unused]]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # -------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 3.14)
-project(PARLAY VERSION 2.2.3
+project(PARLAY VERSION 2.2.4
         DESCRIPTION "A collection of parallel algorithms and other support for parallelism in C++"
         LANGUAGES CXX)
 

--- a/include/parlay/internal/thread_id_pool.h
+++ b/include/parlay/internal/thread_id_pool.h
@@ -47,7 +47,7 @@ class ThreadIdPool : public std::enable_shared_from_this<ThreadIdPool> {
 
 
   ~ThreadIdPool() noexcept {
-    size_t num_destroyed = 0;
+    [[maybe_unused]] size_t num_destroyed = 0;
     for (auto current = available_ids.load(std::memory_order_relaxed); current; num_destroyed++) {
       auto old = std::exchange(current, current->next);
       delete old;


### PR DESCRIPTION
mark a variable only used in an assert as [[maybe_unused]] so that non debug builds don't give warnings when compiling with `-Wunused-but-set-variable`

```
parlaylib/include/parlay/internal/../internal/../internal/thread_id_pool.h:50:12: warning: variable 'num_destroyed' set but not used [-Wunused-but-set-variable]
   50 |     size_t num_destroyed = 0;
```