### PR TITLE
Fix bugs in cycle_count and hash_map

### DIFF
--- a/examples/cycle_count.h
+++ b/examples/cycle_count.h
@@ -1,5 +1,4 @@
 #include <atomic>
-#include <random>
 
 #include <parlay/parallel.h>
 #include <parlay/primitives.h>
@@ -24,14 +23,12 @@ struct lnk {
 
 long cycle_count(parlay::sequence<long>& permutation) {
   long n = permutation.size();
-  parlay::random_generator gen(0);
-  std::uniform_int_distribution<long> dis(0, n-1);
+  auto priority = parlay::random_permutation(n);
   parlay::sequence<lnk> links(n);
   parlay::parallel_for(0, n, [&] (long i) {
     links[i].next = &links[permutation[i]];
     links[permutation[i]].prev = &links[i];
-    auto r = gen[i];
-    links[i].p = dis(r);
+    links[i].p = priority[i];
   });
 
   parlay::parallel_for(0, n, [&] (long i) {
@@ -40,6 +37,7 @@ long cycle_count(parlay::sequence<long>& permutation) {
     links[i].is_leaf = links[i].degree == 0;});
 
   auto roots = parlay::tabulate(n, [&] (long i) {
+    if (permutation[i] == i) return 1;
     if (!links[i].is_leaf) return 0;
     lnk* l = &links[i];
     do {

--- a/examples/hash_map.h
+++ b/examples/hash_map.h
@@ -83,8 +83,11 @@ struct hash_map {
   std::optional<V> find(const K& k) {
     index i = first_index(k);
     while (true) {
-      if (H[i].status != full) return {};
-      if (H[i].key == k) return H[i].value;
+      if (H[i].status == empty || H[i].status == locked) return {};
+      if (H[i].key == k) {
+        if (H[i].status == full) return H[i].value;
+        else return {};
+      }
       i = next_index(i);
     }
   }


### PR DESCRIPTION
This PR fixes several bugs under parlay/examples,

### cycle_count.h

- Bug1: a fixed point of the permutation has degree `(p<p) + (p<=p) == 1`, so it never becomes a leaf and is dropped from the count.
- Bug2: cycles whose randomly-drawn priorities are all tied have no leaf and are dropped too.

### hash_map.h

- Bug: `find` stops probing at any non-`full` slot, including tombstones, while `insert` stores keys past the tombstones — so a live key can become unfindable after an unrelated removal on its probe path.
